### PR TITLE
POC on preextraction

### DIFF
--- a/wix-embedded-mysql/pom.xml
+++ b/wix-embedded-mysql/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.rauschig</groupId>
+            <artifactId>jarchivelib</artifactId>
+            <version>0.7.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/PackagePaths.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/PackagePaths.java
@@ -24,189 +24,34 @@ public class PackagePaths implements IPackageResolver {
         switch (distribution.getPlatform()) {
             case Windows:
                 return buildWindowsFileSet();
+            case OS_X:
+                return buildOSXFileSet();
             default:
                 return buildNixFileSet();
         }
     }
 
+    private FileSet buildOSXFileSet() {
+        return aFileSetBuilder("bin/mysqld", "bin/mysql", "bin/resolveip", "bin/mysqladmin", "bin/my_print_defaults",
+                "scripts/mysql_install_db", "lib/plugin/innodb_engine.so", "share/english/errmsg.sys",
+                "share/fill_help_tables.sql", "share/mysql_security_commands.sql", "share/mysql_system_tables.sql",
+                "share/mysql_system_tables_data.sql", "support-files/my-default.cnf")
+                .build();
+    }
+
     private FileSet buildWindowsFileSet() {
-
-        //TODO: just wow! Ok, need to think of a way to extend flapdoodle process library to support folders instead of individual files;
-        // and discuss with flapdoodle people;
-        FileSet.Builder builder = FileSet.builder()
-                .addEntry(Executable, "bin/mysqld.exe")
-                .addEntry(Library, "bin/mysql.exe")
-                .addEntry(Library, "bin/resolveip.exe")
-                .addEntry(Library, "bin/mysqladmin.exe")
-                .addEntry(Library, "share/english/errmsg.sys")
-                .addEntry(Library, "data/test/db.opt")
-
-                .addEntry(Library, "data/ib_logfile0")
-                .addEntry(Library, "data/ib_logfile1")
-                .addEntry(Library, "data/ibdata1")
-
-                .addEntry(Library, "data/mysql/columns_priv.MYD")
-                .addEntry(Library, "data/mysql/columns_priv.MYI")
-                .addEntry(Library, "data/mysql/columns_priv.frm")
-                .addEntry(Library, "data/mysql/db.MYD")
-                .addEntry(Library, "data/mysql/db.MYI")
-                .addEntry(Library, "data/mysql/db.frm")
-                .addEntry(Library, "data/mysql/event.MYD")
-                .addEntry(Library, "data/mysql/event.MYI")
-                .addEntry(Library, "data/mysql/event.frm")
-                .addEntry(Library, "data/mysql/func.MYD")
-                .addEntry(Library, "data/mysql/func.MYI")
-                .addEntry(Library, "data/mysql/func.frm")
-                .addEntry(Library, "data/mysql/general_log.CSM")
-                .addEntry(Library, "data/mysql/general_log.CSV")
-                .addEntry(Library, "data/mysql/general_log.frm")
-                .addEntry(Library, "data/mysql/help_category.MYD")
-                .addEntry(Library, "data/mysql/help_category.MYI")
-                .addEntry(Library, "data/mysql/help_category.frm")
-                .addEntry(Library, "data/mysql/help_keyword.MYD")
-                .addEntry(Library, "data/mysql/help_keyword.MYI")
-                .addEntry(Library, "data/mysql/help_keyword.frm")
-                .addEntry(Library, "data/mysql/help_relation.MYD")
-                .addEntry(Library, "data/mysql/help_relation.MYI")
-                .addEntry(Library, "data/mysql/help_relation.frm")
-                .addEntry(Library, "data/mysql/help_topic.MYD")
-                .addEntry(Library, "data/mysql/help_topic.MYI")
-                .addEntry(Library, "data/mysql/help_topic.frm")
-                .addEntry(Library, "data/mysql/innodb_index_stats.frm")
-                .addEntry(Library, "data/mysql/innodb_index_stats.ibd")
-                .addEntry(Library, "data/mysql/innodb_table_stats.frm")
-                .addEntry(Library, "data/mysql/innodb_table_stats.ibd")
-                .addEntry(Library, "data/mysql/ndb_binlog_index.MYD")
-                .addEntry(Library, "data/mysql/ndb_binlog_index.MYI")
-                .addEntry(Library, "data/mysql/ndb_binlog_index.frm")
-                .addEntry(Library, "data/mysql/plugin.MYD")
-                .addEntry(Library, "data/mysql/plugin.MYI")
-                .addEntry(Library, "data/mysql/plugin.frm")
-                .addEntry(Library, "data/mysql/proc.MYD")
-                .addEntry(Library, "data/mysql/proc.MYI")
-                .addEntry(Library, "data/mysql/proc.frm")
-                .addEntry(Library, "data/mysql/procs_priv.MYD")
-                .addEntry(Library, "data/mysql/procs_priv.MYI")
-                .addEntry(Library, "data/mysql/procs_priv.frm")
-                .addEntry(Library, "data/mysql/proxies_priv.MYD")
-                .addEntry(Library, "data/mysql/proxies_priv.MYI")
-                .addEntry(Library, "data/mysql/proxies_priv.frm")
-                .addEntry(Library, "data/mysql/servers.MYD")
-                .addEntry(Library, "data/mysql/servers.MYI")
-                .addEntry(Library, "data/mysql/servers.frm")
-                .addEntry(Library, "data/mysql/slave_master_info.frm")
-                .addEntry(Library, "data/mysql/slave_master_info.ibd")
-                .addEntry(Library, "data/mysql/slave_relay_log_info.frm")
-                .addEntry(Library, "data/mysql/slave_relay_log_info.ibd")
-                .addEntry(Library, "data/mysql/slave_worker_info.frm")
-                .addEntry(Library, "data/mysql/slave_worker_info.ibd")
-                .addEntry(Library, "data/mysql/slow_log.CSM")
-                .addEntry(Library, "data/mysql/slow_log.CSV")
-                .addEntry(Library, "data/mysql/slow_log.frm")
-                .addEntry(Library, "data/mysql/tables_priv.MYD")
-                .addEntry(Library, "data/mysql/tables_priv.MYI")
-                .addEntry(Library, "data/mysql/tables_priv.frm")
-                .addEntry(Library, "data/mysql/time_zone.MYD")
-                .addEntry(Library, "data/mysql/time_zone.MYI")
-                .addEntry(Library, "data/mysql/time_zone.frm")
-                .addEntry(Library, "data/mysql/time_zone_leap_second.MYD")
-                .addEntry(Library, "data/mysql/time_zone_leap_second.MYI")
-                .addEntry(Library, "data/mysql/time_zone_leap_second.frm")
-                .addEntry(Library, "data/mysql/time_zone_name.MYD")
-                .addEntry(Library, "data/mysql/time_zone_name.MYI")
-                .addEntry(Library, "data/mysql/time_zone_name.frm")
-                .addEntry(Library, "data/mysql/time_zone_transition.MYD")
-                .addEntry(Library, "data/mysql/time_zone_transition.MYI")
-                .addEntry(Library, "data/mysql/time_zone_transition.frm")
-                .addEntry(Library, "data/mysql/time_zone_transition_type.MYD")
-                .addEntry(Library, "data/mysql/time_zone_transition_type.MYI")
-                .addEntry(Library, "data/mysql/time_zone_transition_type.frm")
-                .addEntry(Library, "data/mysql/user.MYD")
-                .addEntry(Library, "data/mysql/user.MYI")
-                .addEntry(Library, "data/mysql/user.frm")
-
-                .addEntry(Library, "data/performance_schema/accounts.frm")
-                .addEntry(Library, "data/performance_schema/cond_instances.frm")
-                .addEntry(Library, "data/performance_schema/db.opt")
-                .addEntry(Library, "data/performance_schema/events_stages_current.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_history.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_history_long.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_summary_by_account_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_summary_by_host_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_summary_by_thread_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_summary_by_user_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_stages_summary_global_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_current.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_history.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_history_long.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_summary_by_account_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_summary_by_digest.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_summary_by_host_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_summary_by_thread_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_summary_by_user_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_statements_summary_global_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_current.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_history.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_history_long.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_summary_by_account_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_summary_by_host_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_summary_by_instance.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_summary_by_thread_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_summary_by_user_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/events_waits_summary_global_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/file_instances.frm")
-                .addEntry(Library, "data/performance_schema/file_summary_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/file_summary_by_instance.frm")
-                .addEntry(Library, "data/performance_schema/host_cache.frm")
-                .addEntry(Library, "data/performance_schema/hosts.frm")
-                .addEntry(Library, "data/performance_schema/mutex_instances.frm")
-                .addEntry(Library, "data/performance_schema/objects_summary_global_by_type.frm")
-                .addEntry(Library, "data/performance_schema/performance_timers.frm")
-                .addEntry(Library, "data/performance_schema/rwlock_instances.frm")
-                .addEntry(Library, "data/performance_schema/session_account_connect_attrs.frm")
-                .addEntry(Library, "data/performance_schema/session_connect_attrs.frm")
-                .addEntry(Library, "data/performance_schema/setup_actors.frm")
-                .addEntry(Library, "data/performance_schema/setup_consumers.frm")
-                .addEntry(Library, "data/performance_schema/setup_instruments.frm")
-                .addEntry(Library, "data/performance_schema/setup_objects.frm")
-                .addEntry(Library, "data/performance_schema/setup_timers.frm")
-                .addEntry(Library, "data/performance_schema/socket_instances.frm")
-                .addEntry(Library, "data/performance_schema/socket_summary_by_event_name.frm")
-                .addEntry(Library, "data/performance_schema/socket_summary_by_instance.frm")
-                .addEntry(Library, "data/performance_schema/table_io_waits_summary_by_index_usage.frm")
-                .addEntry(Library, "data/performance_schema/table_io_waits_summary_by_table.frm")
-                .addEntry(Library, "data/performance_schema/table_lock_waits_summary_by_table.frm")
-                .addEntry(Library, "data/performance_schema/threads.frm")
-                .addEntry(Library, "data/performance_schema/users.frm");
-
-
-
-        //TODO: patch up process library to support multi-match pattern.
-        //then we could just have regex and mark it as multi-match and no file-counting
-        //as this one is dodgy especially when considering multiple versions etc.
-        //for (int i = 0; i <= 3; i++)  { builder.addEntry(Library, "data/ib.*", "data/ib.*"); }
-        //for (int i = 0; i <= 79; i++) { builder.addEntry(Library, "data/mysql/.*"); }
-        //for (int i = 0; i <= 53; i++) { builder.addEntry(Library, "data/performance_schema/.*"); }
-
-        return builder.build();
+        //TODO: data folder added as somewhat hack.
+        return aFileSetBuilder("bin/mysqld.exe", "bin/mysql.exe", "bin/resolveip.exe", "bin/mysqladmin.exe",
+                "share/english/errmsg.sys")
+                .addEntry(Library, "data", "FOLDER")
+                .build();
     }
 
     private FileSet buildNixFileSet() {
-        return FileSet.builder()
-                .addEntry(Executable, "bin/mysqld")
-                .addEntry(Library,    "bin/mysql")
-                .addEntry(Library,    "bin/resolveip")
-                .addEntry(Library,    "bin/mysqladmin")
-                .addEntry(Library,    "bin/my_print_defaults")
-                .addEntry(Library,    "scripts/mysql_install_db")
-                .addEntry(Library,    "lib/plugin/innodb_engine.so")
-                .addEntry(Library,    "lib/plugin/auth_socket.so")
-                .addEntry(Library,    "share/english/errmsg.sys")
-                .addEntry(Library,    "share/fill_help_tables.sql")
-                .addEntry(Library,    "share/mysql_security_commands.sql")
-                .addEntry(Library,    "share/mysql_system_tables.sql")
-                .addEntry(Library,    "share/mysql_system_tables_data.sql")
-                .addEntry(Library,    "support-files/my-default.cnf")
+        return aFileSetBuilder("bin/mysqld", "bin/mysql", "bin/resolveip", "bin/mysqladmin", "bin/my_print_defaults",
+                "scripts/mysql_install_db", "lib/plugin/innodb_engine.so", "lib/plugin/auth_socket.so", "share/english/errmsg.sys",
+                "share/fill_help_tables.sql", "share/mysql_security_commands.sql", "share/mysql_system_tables.sql",
+                "share/mysql_system_tables_data.sql", "support-files/my-default.cnf")
                 .build();
     }
 
@@ -241,5 +86,13 @@ public class PackagePaths implements IPackageResolver {
             default:
                 throw new RuntimeException("Not implemented for: " + distribution.getPlatform());
         }
+    }
+
+    private FileSet.Builder aFileSetBuilder(String exec, String... libraries) {
+        FileSet.Builder builder = FileSet.builder().addEntry(Executable, exec);
+        for (String name : libraries) {
+            builder.addEntry(Library, name);
+        }
+        return builder;
     }
 }

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/PackagePaths.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/PackagePaths.java
@@ -1,6 +1,8 @@
 package com.wix.mysql;
 
+import com.wix.mysql.distribution.Version;
 import de.flapdoodle.embed.process.config.store.FileSet;
+import de.flapdoodle.embed.process.config.store.FileType;
 import de.flapdoodle.embed.process.config.store.IPackageResolver;
 import de.flapdoodle.embed.process.distribution.ArchiveType;
 import de.flapdoodle.embed.process.distribution.BitSize;
@@ -21,38 +23,68 @@ import static java.lang.String.format;
 public class PackagePaths implements IPackageResolver {
     @Override
     public FileSet getFileSet(Distribution distribution) {
+        Version version = (Version)distribution.getVersion();
         switch (distribution.getPlatform()) {
             case Windows:
                 return buildWindowsFileSet();
             case OS_X:
-                return buildOSXFileSet();
+                return buildOSXFileSet(version);
             default:
-                return buildNixFileSet();
+                return buildNixFileSet((Version)distribution.getVersion());
         }
     }
 
-    private FileSet buildOSXFileSet() {
-        return aFileSetBuilder("bin/mysqld", "bin/mysql", "bin/resolveip", "bin/mysqladmin", "bin/my_print_defaults",
-                "scripts/mysql_install_db", "lib/plugin/innodb_engine.so", "share/english/errmsg.sys",
-                "share/fill_help_tables.sql", "share/mysql_security_commands.sql", "share/mysql_system_tables.sql",
-                "share/mysql_system_tables_data.sql", "support-files/my-default.cnf")
-                .build();
+    private FileSet buildOSXFileSet(Version version) {
+        FileSet.Builder builder = aFileSetBuilder(
+                "bin/mysqld",
+                "bin/mysql",
+                "bin/resolveip",
+                "bin/mysqladmin",
+                "bin/my_print_defaults",
+                "scripts/mysql_install_db",
+                "share/english/errmsg.sys",
+                "share/fill_help_tables.sql",
+                "share/mysql_system_tables.sql",
+                "share/mysql_system_tables_data.sql");
+
+        if (version.majorVersion() == "5.6") {
+            builder.addEntry(FileType.Library, "support-files/my-default.cnf")
+                .addEntry(FileType.Library, "share/mysql_security_commands.sql");
+        }
+
+        return builder.build();
     }
 
     private FileSet buildWindowsFileSet() {
-        //TODO: data folder added as somewhat hack.
-        return aFileSetBuilder("bin/mysqld.exe", "bin/mysql.exe", "bin/resolveip.exe", "bin/mysqladmin.exe",
+        return aFileSetBuilder(
+                "bin/mysqld.exe",
+                "bin/mysql.exe",
+                "bin/resolveip.exe",
+                "bin/mysqladmin.exe",
                 "share/english/errmsg.sys")
-                .addEntry(Library, "data", "FOLDER")
+                .addEntry(Library, "data", "FOLDER")//TODO: data folder added as somewhat hack.
                 .build();
     }
 
-    private FileSet buildNixFileSet() {
-        return aFileSetBuilder("bin/mysqld", "bin/mysql", "bin/resolveip", "bin/mysqladmin", "bin/my_print_defaults",
-                "scripts/mysql_install_db", "lib/plugin/innodb_engine.so", "lib/plugin/auth_socket.so", "share/english/errmsg.sys",
-                "share/fill_help_tables.sql", "share/mysql_security_commands.sql", "share/mysql_system_tables.sql",
-                "share/mysql_system_tables_data.sql", "support-files/my-default.cnf")
-                .build();
+    private FileSet buildNixFileSet(Version version) {
+        FileSet.Builder builder = aFileSetBuilder(
+                "bin/mysqld",
+                "bin/mysql",
+                "bin/resolveip",
+                "bin/mysqladmin",
+                "bin/my_print_defaults",
+                "scripts/mysql_install_db",
+                "share/english/errmsg.sys",
+                "share/fill_help_tables.sql",
+                "share/mysql_system_tables.sql",
+                "share/mysql_system_tables_data.sql");
+
+        if (version.majorVersion() == "5.6") {
+            builder.addEntry(FileType.Library, "support-files/my-default.cnf")
+                    .addEntry(FileType.Library, "share/mysql_security_commands.sql");
+        }
+
+        return builder.build();
     }
 
 

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
@@ -1,25 +1,29 @@
 package com.wix.mysql.config;
 
-import com.google.common.io.Files;
+
 import com.wix.mysql.config.directories.TargetGeneratedFixedPath;
 import com.wix.mysql.config.extract.NopNaming;
 import de.flapdoodle.embed.process.config.store.FileSet;
 import de.flapdoodle.embed.process.config.store.IDownloadConfig;
-import de.flapdoodle.embed.process.config.store.IPackageResolver;
 import de.flapdoodle.embed.process.distribution.Distribution;
-import de.flapdoodle.embed.process.extract.*;
+import de.flapdoodle.embed.process.extract.IExtractedFileSet;
+import de.flapdoodle.embed.process.extract.ITempNaming;
+import de.flapdoodle.embed.process.extract.ImmutableExtractedFileSet;
 import de.flapdoodle.embed.process.io.directories.IDirectory;
-import de.flapdoodle.embed.process.store.*;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import de.flapdoodle.embed.process.store.ArtifactStore;
+import de.flapdoodle.embed.process.store.Downloader;
+import de.flapdoodle.embed.process.store.IArtifactStore;
+import de.flapdoodle.embed.process.store.IDownloader;
 import org.rauschig.jarchivelib.ArchiveFormat;
 import org.rauschig.jarchivelib.ArchiverFactory;
 import org.rauschig.jarchivelib.CompressionType;
-import static de.flapdoodle.embed.process.config.store.FileType.Executable;
-import static de.flapdoodle.embed.process.config.store.FileType.Library;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.file.Files;
+
+import static de.flapdoodle.embed.process.config.store.FileType.Executable;
+import static de.flapdoodle.embed.process.config.store.FileType.Library;
 
 
 /**
@@ -99,7 +103,7 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
             for (FileSet.Entry entry : filesToExtract.entries()) {
                 File source = new File(sourceFolder, entry.destination());
                 File target = new File(destinationFolder, entry.destination());
-                Files.copy(source, target);
+                Files.copy(source.toPath(), target.toPath());
                 target.setExecutable(true);
                 if (entry.type() == Executable) {
                     builder.executable(target);
@@ -108,32 +112,7 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
                 }
             }
 
-//            IPackageResolver packageResolver = this.downloadConfig.getPackageResolver();
-//            FilesToExtract toExtract = new FilesToExtract(this.tempDirFactory, this.executableNaming, packageResolver.getFileSet(distribution));
-//            toExtract.generatedBaseDir();
-
-
-
-//            IPackageResolver packageResolver = this._downloadConfig.getPackageResolver();
-//            File artifact = LocalArtifactStore.getArtifact(this._downloadConfig, distribution);
-//            IExtractor extractor = Extractors.getExtractor(packageResolver.getArchiveType(distribution));
-//            IExtractedFileSet extracted = extractor.extract(this._downloadConfig, artifact, new FilesToExtract(this._tempDirFactory, this._executableNaming, packageResolver.getFileSet(distribution)));
-
-
-//            return super.extractFileSet(distribution);
-
             return builder.build();
-        }
-
-        private File getExtractedFolderPath(File downloadedFile) {
-            String fileName = downloadedFile.getName();
-            String parentFolder = downloadedFile.getParent();
-
-            if (fileName.endsWith(".zip")) {
-                return new File(parentFolder, fileName.replace(".zip", ""));
-            } else {
-                return new File(parentFolder, fileName.replace(".tar.gz", ""));
-            }
         }
 
         private File preExtract(File downloadedFile) throws IOException {

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
@@ -1,8 +1,22 @@
 package com.wix.mysql.config;
 
+import com.wix.mysql.ExtractingDownloader;
 import com.wix.mysql.config.directories.TargetGeneratedFixedPath;
 import com.wix.mysql.config.extract.NopNaming;
-import de.flapdoodle.embed.process.store.Downloader;
+import de.flapdoodle.embed.process.builder.TypedProperty;
+import de.flapdoodle.embed.process.config.store.IDownloadConfig;
+import de.flapdoodle.embed.process.config.store.ILibraryStore;
+import de.flapdoodle.embed.process.distribution.Distribution;
+import de.flapdoodle.embed.process.extract.IExtractedFileSet;
+import de.flapdoodle.embed.process.extract.ITempNaming;
+import de.flapdoodle.embed.process.io.directories.IDirectory;
+import de.flapdoodle.embed.process.store.*;
+import org.rauschig.jarchivelib.ArchiveFormat;
+import org.rauschig.jarchivelib.ArchiverFactory;
+import org.rauschig.jarchivelib.CompressionType;
+
+import java.io.File;
+import java.io.IOException;
 
 
 /**
@@ -11,11 +25,16 @@ import de.flapdoodle.embed.process.store.Downloader;
  */
 public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.ArtifactStoreBuilder {
 
+    private final IDirectory tempDir = new TargetGeneratedFixedPath("mysql");
+    private final NopNaming executableNaming = new NopNaming();
+    private final IDownloadConfig downloadConfig = new DownloadConfigBuilder().defaults().build();
+    private final IDownloader downloader = new Downloader();
+
     public ArtifactStoreBuilder defaults() {
-        tempDir().setDefault(new TargetGeneratedFixedPath("mysql"));
-        executableNaming().setDefault(new NopNaming());
-        download().setDefault(new DownloadConfigBuilder().defaults().build());
-        downloader().setDefault(new Downloader());
+        tempDir().setDefault(tempDir);
+        executableNaming().setDefault(executableNaming);
+        download().setDefault(downloadConfig);
+        downloader().setDefault(downloader);
         /**
          * Disabled caching artifact store, as our use case is to start mysqld before all tests and shutdown afterwards;
          * Caching artifact has some magic, where it has clean-up threads/shutdown hooks and in some cases
@@ -24,5 +43,68 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
          */
         useCache(false);
         return this;
+    }
+
+    @Override
+    public IArtifactStore build() {
+        Object artifactStore = new MyArtifactStore(downloadConfig, tempDir, executableNaming, downloader);
+        return (IArtifactStore)artifactStore;
+
+    }
+
+    public static class MyArtifactStore extends ArtifactStore {
+
+        private IDownloadConfig downloadConfig;
+
+        public MyArtifactStore(IDownloadConfig downloadConfig, IDirectory tempDirFactory, ITempNaming executableNaming, IDownloader downloader) {
+            super(downloadConfig, tempDirFactory, executableNaming, downloader);
+            this.downloadConfig = downloadConfig;
+        }
+
+        @Override
+        public boolean checkDistribution(Distribution distribution) throws IOException {
+            return super.checkDistribution(distribution);
+        }
+
+        @Override
+        public IExtractedFileSet extractFileSet(Distribution distribution) throws IOException {
+            File archive = getArtifact(downloadConfig, distribution);
+            File extractedFiles = preExtract(archive);
+            return super.extractFileSet(distribution);
+        }
+
+        private File preExtract(File downloadedFile) throws IOException {
+            File outputFolder = new File(downloadedFile.getParentFile(), "." + downloadedFile.getName());
+
+            if (downloadedFile.getAbsolutePath().endsWith(".zip")) {
+                ArchiverFactory.createArchiver(ArchiveFormat.ZIP).extract(downloadedFile, outputFolder);
+            } else {
+                ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.GZIP).extract(downloadedFile, outputFolder);
+            }
+
+            return downloadedFile;
+
+        }
+
+        private static File getArtifact(IDownloadConfig runtime, Distribution distribution) {
+            File dir = createOrGetBaseDir(runtime);
+            File artifactFile = new File(dir, runtime.getPackageResolver().getPath(distribution));
+            return artifactFile.exists() && artifactFile.isFile()?artifactFile:null;
+        }
+
+        private static File createOrGetBaseDir(IDownloadConfig runtime) {
+            File dir = runtime.getArtifactStorePath().asFile();
+            createOrCheckDir(dir);
+            return dir;
+        }
+
+        private static void createOrCheckDir(File dir) {
+            if(!dir.exists() && !dir.mkdirs()) {
+                throw new IllegalArgumentException("Could NOT create Directory " + dir);
+            } else if(!dir.isDirectory()) {
+                throw new IllegalArgumentException("" + dir + " is not a Directory");
+            }
+        }
+
     }
 }

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
@@ -54,8 +54,7 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
 
     @Override
     public IArtifactStore build() {
-        Object artifactStore = new MyArtifactStore(downloadConfig, tempDir, executableNaming, downloader);
-        return (IArtifactStore)artifactStore;
+        return new MyArtifactStore(downloadConfig, tempDir, executableNaming, downloader);
     }
 
     public static class MyArtifactStore extends ArtifactStore {
@@ -69,6 +68,7 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
             this.tempDirFactory = tempDirFactory;
         }
 
+        //TODO: move to proper place, here just to prove the point
         FileSet filesToExtract = FileSet.builder()
         .addEntry(Executable, "bin/mysqld")
         .addEntry(Library,    "bin/mysql")
@@ -86,11 +86,6 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
         .addEntry(Library,    "support-files/my-default.cnf")
         .build();
 
-
-        @Override
-        public boolean checkDistribution(Distribution distribution) throws IOException {
-            return super.checkDistribution(distribution);
-        }
 
         @Override
         public IExtractedFileSet extractFileSet(Distribution distribution) throws IOException {

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
@@ -14,6 +14,7 @@ import de.flapdoodle.embed.process.store.ArtifactStore;
 import de.flapdoodle.embed.process.store.Downloader;
 import de.flapdoodle.embed.process.store.IArtifactStore;
 import de.flapdoodle.embed.process.store.IDownloader;
+import org.apache.commons.io.FileUtils;
 import org.rauschig.jarchivelib.ArchiveFormat;
 import org.rauschig.jarchivelib.ArchiverFactory;
 import org.rauschig.jarchivelib.CompressionType;
@@ -21,6 +22,7 @@ import org.rauschig.jarchivelib.CompressionType;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import static de.flapdoodle.embed.process.config.store.FileType.Executable;
 
@@ -79,12 +81,11 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
                 File source = new File(sourceFolder, entry.destination());
                 File target = new File(destinationFolder, entry.destination());
 
-                if (entry.destination().equals(".*FOLDER")) {
-                    target.mkdirs();
-                    Files.copy(source.toPath(), target.toPath());
+                if (entry.matchingPattern().pattern().equals("FOLDER")) {
+                    FileUtils.copyDirectory(source, target);
                 } else {
                     target.getParentFile().mkdirs();
-                    Files.copy(source.toPath(), target.toPath());
+                    FileUtils.copyFile(source, target);
                     target.setExecutable(true);
                 }
 
@@ -107,7 +108,13 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
                 }
             }
 
-            return extractedFolder.listFiles()[0];
+            File[] folders = extractedFolder.listFiles();
+
+            if (folders.length == 1) {
+                return extractedFolder.listFiles()[0];
+            } else {
+                return extractedFolder;
+            }
         }
 
         private File getArtifact(IDownloadConfig runtime, Distribution distribution) {

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/ArtifactStoreBuilder.java
@@ -1,21 +1,24 @@
 package com.wix.mysql.config;
 
-import com.wix.mysql.ExtractingDownloader;
+import com.google.common.io.Files;
 import com.wix.mysql.config.directories.TargetGeneratedFixedPath;
 import com.wix.mysql.config.extract.NopNaming;
-import de.flapdoodle.embed.process.builder.TypedProperty;
+import de.flapdoodle.embed.process.config.store.FileSet;
 import de.flapdoodle.embed.process.config.store.IDownloadConfig;
-import de.flapdoodle.embed.process.config.store.ILibraryStore;
+import de.flapdoodle.embed.process.config.store.IPackageResolver;
 import de.flapdoodle.embed.process.distribution.Distribution;
-import de.flapdoodle.embed.process.extract.IExtractedFileSet;
-import de.flapdoodle.embed.process.extract.ITempNaming;
+import de.flapdoodle.embed.process.extract.*;
 import de.flapdoodle.embed.process.io.directories.IDirectory;
 import de.flapdoodle.embed.process.store.*;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.rauschig.jarchivelib.ArchiveFormat;
 import org.rauschig.jarchivelib.ArchiverFactory;
 import org.rauschig.jarchivelib.CompressionType;
+import static de.flapdoodle.embed.process.config.store.FileType.Executable;
+import static de.flapdoodle.embed.process.config.store.FileType.Library;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 
 
@@ -49,17 +52,36 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
     public IArtifactStore build() {
         Object artifactStore = new MyArtifactStore(downloadConfig, tempDir, executableNaming, downloader);
         return (IArtifactStore)artifactStore;
-
     }
 
     public static class MyArtifactStore extends ArtifactStore {
 
         private IDownloadConfig downloadConfig;
+        private IDirectory tempDirFactory;
 
         public MyArtifactStore(IDownloadConfig downloadConfig, IDirectory tempDirFactory, ITempNaming executableNaming, IDownloader downloader) {
             super(downloadConfig, tempDirFactory, executableNaming, downloader);
             this.downloadConfig = downloadConfig;
+            this.tempDirFactory = tempDirFactory;
         }
+
+        FileSet filesToExtract = FileSet.builder()
+        .addEntry(Executable, "bin/mysqld")
+        .addEntry(Library,    "bin/mysql")
+        .addEntry(Library,    "bin/resolveip")
+        .addEntry(Library,    "bin/mysqladmin")
+        .addEntry(Library,    "bin/my_print_defaults")
+        .addEntry(Library,    "scripts/mysql_install_db")
+        .addEntry(Library,    "lib/plugin/innodb_engine.so")
+        //.addEntry(Library,    "lib/plugin/auth_socket.so")//only linux
+        .addEntry(Library,    "share/english/errmsg.sys")
+        .addEntry(Library,    "share/fill_help_tables.sql")
+        .addEntry(Library,    "share/mysql_security_commands.sql")
+        .addEntry(Library,    "share/mysql_system_tables.sql")
+        .addEntry(Library,    "share/mysql_system_tables_data.sql")
+        .addEntry(Library,    "support-files/my-default.cnf")
+        .build();
+
 
         @Override
         public boolean checkDistribution(Distribution distribution) throws IOException {
@@ -69,21 +91,63 @@ public class ArtifactStoreBuilder extends de.flapdoodle.embed.process.store.Arti
         @Override
         public IExtractedFileSet extractFileSet(Distribution distribution) throws IOException {
             File archive = getArtifact(downloadConfig, distribution);
-            File extractedFiles = preExtract(archive);
-            return super.extractFileSet(distribution);
+            File sourceFolder = preExtract(archive);
+            File destinationFolder = tempDirFactory.asFile();
+            destinationFolder.mkdir();
+            ImmutableExtractedFileSet.Builder builder = ImmutableExtractedFileSet.builder(destinationFolder);
+
+            for (FileSet.Entry entry : filesToExtract.entries()) {
+                File source = new File(sourceFolder, entry.destination());
+                File target = new File(destinationFolder, entry.destination());
+                Files.copy(source, target);
+                target.setExecutable(true);
+                if (entry.type() == Executable) {
+                    builder.executable(target);
+                } else {
+                    builder.file(entry.type(), target);
+                }
+            }
+
+//            IPackageResolver packageResolver = this.downloadConfig.getPackageResolver();
+//            FilesToExtract toExtract = new FilesToExtract(this.tempDirFactory, this.executableNaming, packageResolver.getFileSet(distribution));
+//            toExtract.generatedBaseDir();
+
+
+
+//            IPackageResolver packageResolver = this._downloadConfig.getPackageResolver();
+//            File artifact = LocalArtifactStore.getArtifact(this._downloadConfig, distribution);
+//            IExtractor extractor = Extractors.getExtractor(packageResolver.getArchiveType(distribution));
+//            IExtractedFileSet extracted = extractor.extract(this._downloadConfig, artifact, new FilesToExtract(this._tempDirFactory, this._executableNaming, packageResolver.getFileSet(distribution)));
+
+
+//            return super.extractFileSet(distribution);
+
+            return builder.build();
+        }
+
+        private File getExtractedFolderPath(File downloadedFile) {
+            String fileName = downloadedFile.getName();
+            String parentFolder = downloadedFile.getParent();
+
+            if (fileName.endsWith(".zip")) {
+                return new File(parentFolder, fileName.replace(".zip", ""));
+            } else {
+                return new File(parentFolder, fileName.replace(".tar.gz", ""));
+            }
         }
 
         private File preExtract(File downloadedFile) throws IOException {
-            File outputFolder = new File(downloadedFile.getParentFile(), "." + downloadedFile.getName());
+            File extractedFolder = new File(downloadedFile.getAbsolutePath() + "_extracted");
 
-            if (downloadedFile.getAbsolutePath().endsWith(".zip")) {
-                ArchiverFactory.createArchiver(ArchiveFormat.ZIP).extract(downloadedFile, outputFolder);
-            } else {
-                ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.GZIP).extract(downloadedFile, outputFolder);
+            if (!extractedFolder.exists()) {
+                if (downloadedFile.getAbsolutePath().endsWith(".zip")) {
+                    ArchiverFactory.createArchiver(ArchiveFormat.ZIP).extract(downloadedFile, extractedFolder);
+                } else {
+                    ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.GZIP).extract(downloadedFile, extractedFolder);
+                }
             }
 
-            return downloadedFile;
-
+            return extractedFolder.listFiles()[0];
         }
 
         private static File getArtifact(IDownloadConfig runtime, Distribution distribution) {

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/directories/TargetGeneratedFixedPath.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/directories/TargetGeneratedFixedPath.java
@@ -1,37 +1,27 @@
 package com.wix.mysql.config.directories;
 
-import de.flapdoodle.embed.process.distribution.Platform;
 import de.flapdoodle.embed.process.io.directories.IDirectory;
 
 import java.io.File;
 import java.util.UUID;
+
+import static java.lang.String.format;
 
 public class TargetGeneratedFixedPath implements IDirectory {
 
     private final String baseDir;
 
     public TargetGeneratedFixedPath(String prefix) {
-        this.baseDir = String.format("target/%s-%s", prefix, UUID.randomUUID().toString());
+        this.baseDir = format("target/%s-%s", prefix, UUID.randomUUID().toString());
     }
 
     @Override
     public File asFile() {
-        generateNeededDirs();
-        return new File(baseDir).getAbsoluteFile();
-    }
-
-    private void generateNeededDirs() {
-        String[] paths = null;
-
-        if (Platform.detect() == Platform.Windows) {
-            paths = new String[]{ "bin", "share/english", "data/test", "data/mysql", "data/performance_schema" };
-        } else {
-            paths = new String[]{ "bin", "scripts", "lib/plugin", "share/english", "share", "support-files" };
+        File ret = new File(baseDir).getAbsoluteFile();
+        if (!ret.exists()) {
+            ret.mkdir();
         }
-
-        for (String dir: paths) {
-            new File(baseDir + "/" + dir).mkdirs();
-        }
+        return ret;
     }
 
     @Override
@@ -39,4 +29,3 @@ public class TargetGeneratedFixedPath implements IDirectory {
         return true;
     }
 }
-

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
@@ -46,6 +46,7 @@ public enum Version implements IVersion {
     public boolean supportsCurrentPlatform() {
         return supportedPlatforms.contains(currentPlatform());
     }
+    public String majorVersion() { return majorVersion; }
 
     @Override
     public String asInDownloadPath() {

--- a/wix-embedded-mysql/src/test/scala/com/wix/mysql/CustomConfigurationTest.scala
+++ b/wix-embedded-mysql/src/test/scala/com/wix/mysql/CustomConfigurationTest.scala
@@ -20,6 +20,19 @@ class CustomConfigurationTest extends IntegrationTest {
 
   "embedded mysql should apply with" >> {
 
+    "measure start-up" in new Context {
+      val config = template.build
+
+      val before = System.currentTimeMillis()
+
+      val executable: MysqldExecutable = givenMySqlWithConfig(config)
+      try {
+        executable.start()
+        println(System.currentTimeMillis() - before + " ms")
+      } finally executable.stop
+
+    }
+
     "defaults" in new Context {
       val config = template.build
       startAndVerifyDatabase(config)


### PR DESCRIPTION
Ok, so code is dirty and not near the shape where I would merge it, but the whole idea is clear.

Why? 
1. Shaves off of start-up time 3 seconds (out of 9) and in other distros (linux) I think performance improvement wll be bigger;
2. Might solve current issue with listing all the files to extract. It's easy now to redo all PackagePaths situation at make it sane - look at windows version:/ Then mappings to files to extract I would move to ex. Version enum and then tie them to version, as different versions add variations.

Otherwise not that much of hacking/code duplication, but adds some benefits.

@noam-almog WDYT? Worth pursuing?