### PR TITLE
Update guava version to 19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <flapdoodle.process.version>1.50.0</flapdoodle.process.version>
         <spring.jdbc.version>4.1.1.RELEASE</spring.jdbc.version>
         <mysql.connector.version>5.1.36</mysql.connector.version>
-        <google.guava.version>16.0.1</google.guava.version>
+        <google.guava.version>19.0</google.guava.version>
         <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.3</logback.version>
         <scala.library.version>2.11</scala.library.version>


### PR DESCRIPTION
Older guava version is causing issues using this library with other open source projects (in my case it clashes with Jersey Repackaged Guava while using Dropwizard). Please consider upgrading Guava to the latest version.