### PR TITLE
Remove guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <flapdoodle.process.version>1.50.0</flapdoodle.process.version>
         <spring.jdbc.version>4.1.1.RELEASE</spring.jdbc.version>
         <mysql.connector.version>5.1.36</mysql.connector.version>
-        <google.guava.version>16.0.1</google.guava.version>
         <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.3</logback.version>
         <scala.library.version>2.11</scala.library.version>
@@ -56,12 +55,6 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.process</artifactId>
             <version>${flapdoodle.process.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${google.guava.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -1,6 +1,5 @@
 package com.wix.mysql;
 
-import com.google.common.collect.Lists;
 import com.wix.mysql.config.Charset;
 import com.wix.mysql.config.MysqldConfig;
 import com.wix.mysql.config.MysqldConfig.SystemDefaults;
@@ -11,10 +10,12 @@ import de.flapdoodle.embed.process.config.IRuntimeConfig;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.wix.mysql.config.MysqldConfig.SystemDefaults.SCHEMA;
+import static com.wix.mysql.utils.Utils.or;
 import static java.lang.String.format;
 
 /**
@@ -56,7 +57,7 @@ public class EmbeddedMysql {
     }
 
     private EmbeddedMysql addSchema(final SchemaConfig schema) {
-        Charset effectiveCharset = schema.getCharset().or(config.getCharset());
+        Charset effectiveCharset = or(schema.getCharset(), config.getCharset());
 
         getClient(SystemDefaults.SCHEMA).executeCommands(
                 format("CREATE DATABASE %s CHARACTER SET = %s COLLATE = %s;",
@@ -89,7 +90,7 @@ public class EmbeddedMysql {
 
     public static class Builder {
         private final MysqldConfig config;
-        private List<SchemaConfig> schemas = Lists.newArrayList();
+        private List<SchemaConfig> schemas = new ArrayList<>();
 
         public Builder(final MysqldConfig config) {
             this.config = config;

--- a/src/main/java/com/wix/mysql/MysqlClient.java
+++ b/src/main/java/com/wix/mysql/MysqlClient.java
@@ -1,6 +1,5 @@
 package com.wix.mysql;
 
-import com.google.common.base.Strings;
 import com.wix.mysql.config.MysqldConfig;
 import com.wix.mysql.config.MysqldConfig.SystemDefaults;
 import com.wix.mysql.exceptions.CommandFailedException;
@@ -12,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static com.wix.mysql.utils.Utils.isNullOrEmpty;
 import static de.flapdoodle.embed.process.distribution.Platform.Windows;
 import static java.lang.String.format;
 
@@ -59,7 +59,7 @@ class MysqlClient {
                 String out = IOUtils.toString(p.getInputStream());
                 String err = IOUtils.toString(p.getErrorStream());
 
-                if (Strings.isNullOrEmpty(out))
+                if (isNullOrEmpty(out))
                     throw new CommandFailedException(command, schemaName, p.waitFor(), err);
                 else
                     throw new CommandFailedException(command, schemaName, p.waitFor(), out);

--- a/src/main/java/com/wix/mysql/MysqldExecutable.java
+++ b/src/main/java/com/wix/mysql/MysqldExecutable.java
@@ -12,8 +12,10 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * @author viliusl
@@ -62,10 +64,10 @@ class MysqldExecutable extends Executable<MysqldConfig, MysqldProcess> {
                     null,
                     getBaseDir());
 
-            int retCode = p.waitFor();
+            boolean retCode = p.waitFor(30, SECONDS);
 
-            if (retCode != 0) {
-                resolveException(retCode, IOUtils.toString(p.getInputStream()) + IOUtils.toString(p.getErrorStream()));
+            if (!retCode) {
+                resolveException(-1, IOUtils.toString(p.getInputStream()) + IOUtils.toString(p.getErrorStream()));
             }
 
         } catch (InterruptedException e) {

--- a/src/main/java/com/wix/mysql/MysqldExecutable.java
+++ b/src/main/java/com/wix/mysql/MysqldExecutable.java
@@ -12,10 +12,8 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * @author viliusl
@@ -64,10 +62,10 @@ class MysqldExecutable extends Executable<MysqldConfig, MysqldProcess> {
                     null,
                     getBaseDir());
 
-            boolean retCode = p.waitFor(30, SECONDS);
+            int retCode = p.waitFor();
 
-            if (!retCode) {
-                resolveException(-1, IOUtils.toString(p.getInputStream()) + IOUtils.toString(p.getErrorStream()));
+            if (retCode != 0) {
+                resolveException(retCode, IOUtils.toString(p.getInputStream()) + IOUtils.toString(p.getErrorStream()));
             }
 
         } catch (InterruptedException e) {

--- a/src/main/java/com/wix/mysql/MysqldProcess.java
+++ b/src/main/java/com/wix/mysql/MysqldProcess.java
@@ -1,6 +1,5 @@
 package com.wix.mysql;
 
-import com.google.common.io.CharStreams;
 import com.wix.mysql.config.MysqldConfig;
 import com.wix.mysql.io.NotifyingStreamProcessor;
 import com.wix.mysql.io.NotifyingStreamProcessor.ResultMatchingListener;
@@ -25,6 +24,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static com.wix.mysql.utils.Utils.closeCloseables;
+import static com.wix.mysql.utils.Utils.readToString;
 import static java.lang.String.format;
 
 /**
@@ -144,7 +144,7 @@ public class MysqldProcess extends AbstractProcess<MysqldConfig, MysqldExecutabl
                 }
 
             } else {
-                String errOutput = CharStreams.toString(stdErr);
+                String errOutput = readToString(stdErr);
 
                 if (errOutput.contains("Can't connect to MySQL server on")) {
                     logger.warn("mysql was already shutdown - no need to add extra shutdown hook - process does it out of the box.");

--- a/src/main/java/com/wix/mysql/ScriptResolver.java
+++ b/src/main/java/com/wix/mysql/ScriptResolver.java
@@ -1,21 +1,21 @@
 package com.wix.mysql;
 
-import com.google.common.base.Joiner;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static com.wix.mysql.utils.Utils.join;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.copyOfRange;
 
 /**
  * Helper for locating schema init scripts in a classpath.
- * TODO: replace impl with some library - guava or smth.
  *
  * @author viliusl
  * @since 06/06/15
@@ -37,14 +37,14 @@ public class ScriptResolver {
 
     /**
      * Locates classPathFiles matching pattern, ordered using natural alphanumeric order, ex. 'db/*.sql'.
-     *
+     * <p/>
      * Note: Supports only wildcards ('*') and only in file names for matching.
      */
     public static List<File> classPathFiles(final String pattern) {
         List<File> results;
 
         String[] parts = pattern.split("/");
-        String path = Joiner.on("/").join(Arrays.copyOfRange(parts, 0, parts.length - 1));
+        String path = join(asList(copyOfRange(parts, 0, parts.length - 1)), "/");
 
         URL baseFolder = ScriptResolver.class.getResource(path.startsWith("/") ? path : format("/%s", path));
         FileFilter filter = new WildcardFileFilter(parts[parts.length - 1]);
@@ -52,7 +52,7 @@ public class ScriptResolver {
         if (baseFolder == null)
             throw new ScriptResolutionException(path);
 
-        results = Arrays.asList(asFile(baseFolder).listFiles(filter));
+        results = asList(asFile(baseFolder).listFiles(filter));
 
         Collections.sort(results);
 

--- a/src/main/java/com/wix/mysql/config/Charset.java
+++ b/src/main/java/com/wix/mysql/config/Charset.java
@@ -1,6 +1,6 @@
 package com.wix.mysql.config;
 
-import com.google.common.base.Objects;
+import java.util.Arrays;
 
 /**
  * @author viliusl
@@ -19,25 +19,29 @@ public class Charset {
         this.collate = collate;
     }
 
-    public String getCharset() { return charset; }
-
-    public String getCollate() { return collate; }
-
     public static Charset aCharset(final String charset, final String collate) {
         return new Charset(charset, collate);
     }
 
-    public static Charset defaults()  { return UTF8MB4; }
+    public static Charset defaults() {
+        return UTF8MB4;
+    }
 
+    public String getCharset() {
+        return charset;
+    }
+
+    public String getCollate() {
+        return collate;
+    }
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("charset", charset)
-                .add("collate", collate)
-                .toString();
+        return "Charset{" +
+                "charset='" + charset + '\'' +
+                ", collate='" + collate + '\'' +
+                '}';
     }
-
 
     @Override
     public boolean equals(Object o) {
@@ -46,12 +50,16 @@ public class Charset {
 
         Charset that = (Charset) o;
 
-        return Objects.equal(this.charset, that.charset) &&
-                Objects.equal(this.collate, that.collate);
+        return areObjectsEqual(this.charset, that.charset) &&
+                areObjectsEqual(this.collate, that.collate);
+    }
+
+    private <T> boolean areObjectsEqual(T o1, T o2) {
+        return o1 == o2 || (o1 != null && o1.equals(o2));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(charset, collate);
+        return Arrays.hashCode(new Object[]{charset, collate});
     }
 }

--- a/src/main/java/com/wix/mysql/config/SchemaConfig.java
+++ b/src/main/java/com/wix/mysql/config/SchemaConfig.java
@@ -1,9 +1,7 @@
 package com.wix.mysql.config;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -14,12 +12,12 @@ import java.util.List;
 public class SchemaConfig {
 
     private final String name;
-    private final Optional<Charset> charset;
+    private final Charset charset;
     private final List<File> scripts;
 
     private SchemaConfig(
             final String name,
-            final Optional<Charset> charset,
+            final Charset charset,
             final List<File> scripts) {
         this.name = name;
         this.charset = charset;
@@ -31,21 +29,21 @@ public class SchemaConfig {
     }
 
     public String getName() { return name; }
-    public Optional<Charset> getCharset() { return charset; }
+    public Charset getCharset() { return charset; }
     public List<File> getScripts() { return scripts; }
 
     public static class Builder {
 
         private final String name;
-        private Optional<Charset> charset = Optional.absent();
-        private List<File> scripts = Lists.newArrayList();
+        private Charset charset;
+        private List<File> scripts = new ArrayList<>();
 
         public Builder(final String name) {
             this.name = name;
         }
 
         public Builder withCharset(final Charset charset) {
-            this.charset = Optional.of(charset);
+            this.charset = charset;
             return this;
         }
 

--- a/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/src/main/java/com/wix/mysql/distribution/Version.java
@@ -1,7 +1,7 @@
 package com.wix.mysql.distribution;
 
-import com.google.common.base.Joiner;
 import com.wix.mysql.exceptions.UnsupportedPlatformException;
+import com.wix.mysql.utils.Utils;
 import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.process.distribution.Platform;
 
@@ -95,7 +95,7 @@ public enum Version implements IVersion {
         if (!supportsCurrentPlatform()) {
             throw new UnsupportedPlatformException(String.format("Platform %s is not in a supported platform list: %s",
                     currentPlatform().name(),
-                    Joiner.on(",").join(supportedPlatforms)));
+                    Utils.join(supportedPlatforms, ",")));
         }
     }
 

--- a/src/main/java/com/wix/mysql/io/NotifyingStreamProcessor.java
+++ b/src/main/java/com/wix/mysql/io/NotifyingStreamProcessor.java
@@ -1,8 +1,8 @@
 package com.wix.mysql.io;
 
-import com.google.common.collect.Lists;
 import de.flapdoodle.embed.process.io.IStreamProcessor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -11,7 +11,7 @@ import java.util.List;
  */
 public class NotifyingStreamProcessor implements IStreamProcessor {
 
-    private final List<ResultMatchingListener> listeners = Lists.newArrayList();
+    private final List<ResultMatchingListener> listeners = new ArrayList<>();
     private final IStreamProcessor delegate;
 
     public NotifyingStreamProcessor(IStreamProcessor processor) {

--- a/src/main/java/com/wix/mysql/utils/Utils.java
+++ b/src/main/java/com/wix/mysql/utils/Utils.java
@@ -2,6 +2,8 @@ package com.wix.mysql.utils;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.CharBuffer;
+import java.util.List;
 import java.util.TimeZone;
 
 import static java.lang.String.format;
@@ -13,9 +15,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @since 13/02/15
  */
 public class Utils {
-
-    //Cannot use higher version of guava than 16 right now due to framework (wix-embedded-mysql) uses this
-    //TODO: make sure 18 version is in FW
     public static void closeCloseables(Reader... readers) {
 
         for (Reader reader : readers) {
@@ -32,5 +31,33 @@ public class Utils {
                 offsetInMillis >= 0 ? "+" : "-",
                 Math.abs(MILLISECONDS.toHours(offsetInMillis)),
                 MILLISECONDS.toMinutes(offsetInMillis) - HOURS.toMinutes(MILLISECONDS.toHours(offsetInMillis)));
+    }
+
+    public static <T> T or(T arg1, T arg2) {
+        return arg1 != null ? arg1 : arg2;
+    }
+
+    public static boolean isNullOrEmpty(String str) {
+        return str == null || str.isEmpty();
+    }
+
+    public static String join(List<?> list, String delim) {
+        if (list.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(list.get(0).toString());
+        for (int i = 1; i < list.size(); i++) {
+            sb.append(delim).append(list.get(i).toString());
+        }
+        return sb.toString();
+    }
+
+    public static String readToString(Reader reader) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        CharBuffer buf = CharBuffer.allocate(1024);
+        while (reader.read(buf) != -1) {
+            buf.flip();
+            sb.append(buf);
+            buf.clear();
+        }
+        return sb.toString();
     }
 }

--- a/src/test/scala/com/wix/mysql/SchemaConfigTest.scala
+++ b/src/test/scala/com/wix/mysql/SchemaConfigTest.scala
@@ -2,10 +2,8 @@ package com.wix.mysql
 
 import java.io.File
 
-import com.google.common.base.Optional
 import com.wix.mysql.config.Charset.aCharset
 import com.wix.mysql.config.SchemaConfig.aSchemaConfig
-import com.wix.mysql.config.{Charset, SchemaConfig}
 import org.specs2.mutable.SpecWithJUnit
 
 import scala.collection.convert.wrapAll._
@@ -21,7 +19,7 @@ class SchemaConfigTest extends SpecWithJUnit {
       val schemaConfig = aSchemaConfig("aschema").build
 
       schemaConfig.getName mustEqual "aschema"
-      schemaConfig.getCharset mustEqual Optional.absent()
+      schemaConfig.getCharset must beNull
       schemaConfig.getScripts must beEmpty
     }
 
@@ -32,7 +30,7 @@ class SchemaConfigTest extends SpecWithJUnit {
         .withCharset(charset)
         .build
 
-      schemaConfig.getCharset mustEqual Optional.of(charset)
+      schemaConfig.getCharset mustEqual charset
     }
 
     "build with Files" in {


### PR DESCRIPTION
It would be great to remove Guava as dependency to make this library more lightweight. In the future after migration to Java 8 most of Guava features can be replaced with similar functionality from standard library.