### PR TITLE
Add possibility to run arbitrary script in SchemaConfig #36

### DIFF
--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -66,7 +66,9 @@ public class EmbeddedMysql {
                         schema.getName(), effectiveCharset.getCharset(), effectiveCharset.getCollate()),
                 format("GRANT ALL ON %s.* TO '%s'@'%%';", schema.getName(), config.getUsername()));
 
-        getClient(schema.getName()).executeScripts(schema.getScripts());
+        MysqlClient client = getClient(schema.getName());
+        client.executeScripts(schema.getScripts());
+        client.executeCommands(schema.getCommands());
 
         return this;
     }

--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -45,10 +45,12 @@ public class EmbeddedMysql {
         return this.config;
     }
 
+    /** @deprecated Use overload with SchemaConfig */
     public void reloadSchema(final String schemaName, final File... scripts) {
         reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
     }
 
+    /** @deprecated Use overload with SchemaConfig */
     public void reloadSchema(final String schemaName, final List<File> scripts) {
         reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
     }

--- a/src/main/java/com/wix/mysql/MysqlClient.java
+++ b/src/main/java/com/wix/mysql/MysqlClient.java
@@ -43,6 +43,12 @@ class MysqlClient {
         }
     }
 
+    public void executeCommands(final List<String> sqls) {
+        for (String sql : sqls) {
+            execute(sql);
+        }
+    }
+
     private void execute(final String sql) {
         String command = (Platform.detect() == Windows) ? format("\"%s\"", sql) : sql;
         try {

--- a/src/main/java/com/wix/mysql/config/SchemaConfig.java
+++ b/src/main/java/com/wix/mysql/config/SchemaConfig.java
@@ -3,6 +3,7 @@ package com.wix.mysql.config;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -14,14 +15,14 @@ public class SchemaConfig {
     private final String name;
     private final Charset charset;
     private final List<File> scripts;
+    private final List<String> commands;
 
-    private SchemaConfig(
-            final String name,
-            final Charset charset,
-            final List<File> scripts) {
+    private SchemaConfig(String name, Charset charset, List<File> scripts, List<String> commands)
+    {
         this.name = name;
         this.charset = charset;
         this.scripts = scripts;
+        this.commands = commands;
     }
 
     public static Builder aSchemaConfig(final String name) {
@@ -40,11 +41,17 @@ public class SchemaConfig {
         return scripts;
     }
 
+    public List<String> getCommands()
+    {
+        return commands;
+    }
+
     public static class Builder {
 
         private final String name;
         private Charset charset;
-        private List<File> scripts = new ArrayList<>();
+        private List<File> scripts = Collections.emptyList();
+        private List<String> commands = Collections.emptyList();
 
         public Builder(final String name) {
             this.name = name;
@@ -64,8 +71,19 @@ public class SchemaConfig {
             return this;
         }
 
+        public Builder withCommands(final String... commands)
+        {
+            return withCommands(Arrays.asList(commands));
+        }
+
+        public Builder withCommands(final List<String> commands)
+        {
+            this.commands = commands;
+            return this;
+        }
+
         public SchemaConfig build() {
-            return new SchemaConfig(name, charset, scripts);
+            return new SchemaConfig(name, charset, scripts, commands);
         }
     }
 }

--- a/src/main/java/com/wix/mysql/config/SchemaConfig.java
+++ b/src/main/java/com/wix/mysql/config/SchemaConfig.java
@@ -1,7 +1,6 @@
 package com.wix.mysql.config;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,8 +16,7 @@ public class SchemaConfig {
     private final List<File> scripts;
     private final List<String> commands;
 
-    private SchemaConfig(String name, Charset charset, List<File> scripts, List<String> commands)
-    {
+    private SchemaConfig(String name, Charset charset, List<File> scripts, List<String> commands) {
         this.name = name;
         this.charset = charset;
         this.scripts = scripts;
@@ -41,8 +39,7 @@ public class SchemaConfig {
         return scripts;
     }
 
-    public List<String> getCommands()
-    {
+    public List<String> getCommands() {
         return commands;
     }
 
@@ -71,13 +68,11 @@ public class SchemaConfig {
             return this;
         }
 
-        public Builder withCommands(final String... commands)
-        {
+        public Builder withCommands(final String... commands) {
             return withCommands(Arrays.asList(commands));
         }
 
-        public Builder withCommands(final List<String> commands)
-        {
+        public Builder withCommands(final List<String> commands) {
             this.commands = commands;
             return this;
         }

--- a/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
@@ -143,6 +143,7 @@ class EmbeddedMysqlTest extends IntegrationTest {
         .withScripts(
           aMigrationWith("create table t1 (col1 INTEGER);"),
           aMigrationWith("create table t2 (col1 INTEGER);"))
+        .withCommands("create table t3 (col1 INTEGER);")
         .build
 
       mysqld = anEmbeddedMysql(v5_6_latest)
@@ -151,6 +152,7 @@ class EmbeddedMysqlTest extends IntegrationTest {
 
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t1;") must beSuccessful
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t2;") must beSuccessful
+      aQuery(onSchema = "aSchema", sql = "select count(col1) from t3;") must beSuccessful
     }
   }
 }

--- a/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
@@ -45,21 +45,7 @@ class EmbeddedMysqlTest extends IntegrationTest {
   }
 
   "EmbeddedMysql schema reload" should {
-    "reset schema with schema name and migration files" in {
-      mysqld = anEmbeddedMysql(v5_6_latest)
-        .addSchema("aSchema", aMigrationWith("create table t1 (col1 INTEGER);"))
-        .start
-
-      anUpdate(onSchema = "aSchema", sql = "insert into t1 values(10)") must beSuccessful
-      aSelect[java.lang.Long](onSchema = "aSchema", sql = "select col1 from t1 where col1 = 10;") mustEqual 10
-
-      mysqld.reloadSchema("aSchema", aMigrationWith("create table t1 (col1 INTEGER);"))
-
-      aSelect[java.lang.Long](onSchema = "aSchema", sql = "select col1 from t1 where col1 = 10;") must
-        failWith("Incorrect result size: expected 1, actual 0")
-    }
-
-    "reset schema with schema config" in {
+    "reset schema" in {
       val config = aSchemaConfig("aSchema")
         .withScripts(aMigrationWith("create table t1 (col1 INTEGER);"))
         .build

--- a/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
@@ -143,7 +143,11 @@ class EmbeddedMysqlTest extends IntegrationTest {
         .withScripts(
           aMigrationWith("create table t1 (col1 INTEGER);"),
           aMigrationWith("create table t2 (col1 INTEGER);"))
-        .withCommands("create table t3 (col1 INTEGER);")
+        .withCommands(
+          "create table t3 (col1 INTEGER);\n" +
+          "create table t4 (col2 INTEGER)",
+          "create table t5 (col3 INTEGER)"
+        )
         .build
 
       mysqld = anEmbeddedMysql(v5_6_latest)
@@ -153,6 +157,8 @@ class EmbeddedMysqlTest extends IntegrationTest {
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t1;") must beSuccessful
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t2;") must beSuccessful
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t3;") must beSuccessful
+      aQuery(onSchema = "aSchema", sql = "select count(col2) from t4;") must beSuccessful
+      aQuery(onSchema = "aSchema", sql = "select count(col3) from t5;") must beSuccessful
     }
   }
 }

--- a/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
@@ -145,9 +145,7 @@ class EmbeddedMysqlTest extends IntegrationTest {
           aMigrationWith("create table t2 (col1 INTEGER);"))
         .withCommands(
           "create table t3 (col1 INTEGER);\n" +
-          "create table t4 (col2 INTEGER)",
-          "create table t5 (col3 INTEGER)"
-        )
+          "create table t4 (col2 INTEGER)")
         .build
 
       mysqld = anEmbeddedMysql(v5_6_latest)
@@ -158,7 +156,6 @@ class EmbeddedMysqlTest extends IntegrationTest {
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t2;") must beSuccessful
       aQuery(onSchema = "aSchema", sql = "select count(col1) from t3;") must beSuccessful
       aQuery(onSchema = "aSchema", sql = "select count(col2) from t4;") must beSuccessful
-      aQuery(onSchema = "aSchema", sql = "select count(col3) from t5;") must beSuccessful
     }
   }
 }

--- a/src/test/scala/com/wix/mysql/JavaUsageExamplesTest.java
+++ b/src/test/scala/com/wix/mysql/JavaUsageExamplesTest.java
@@ -87,7 +87,10 @@ public class JavaUsageExamplesTest {
 
         //do work
 
-        mysqld.reloadSchema("aschema", classPathFile("db/001_init.sql"));
+        SchemaConfig schema = aSchemaConfig("aschema")
+                .withScripts(classPathFile("db/001_init.sql"))
+                .build();
+        mysqld.reloadSchema(schema);
 
         //continue on doing work
 


### PR DESCRIPTION
@noam-almog @viliusl Take a look, please.

To support "classpath:" for external jars - we need to use spring-core (PathMatchingResourcePatternResolver). I didn't want to add another dependency in this module, so... It's better just to allow to run any sql script in addSchema/reloadSchema.