### PR TITLE
Add addSchema(), dropSchema() to EmbeddedMysql for schema management on started instance

### DIFF
--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -56,11 +56,15 @@ public class EmbeddedMysql {
     }
 
     public void reloadSchema(final SchemaConfig config) {
-        getClient(SystemDefaults.SCHEMA).executeCommands(format("DROP DATABASE %s", config.getName()));
+        dropSchema(config);
         addSchema(config);
     }
 
-    private EmbeddedMysql addSchema(final SchemaConfig schema) {
+    public void dropSchema(final SchemaConfig config) {
+        getClient(SystemDefaults.SCHEMA).executeCommands(format("DROP DATABASE %s", config.getName()));
+    }
+
+    public EmbeddedMysql addSchema(final SchemaConfig schema) {
         Charset effectiveCharset = or(schema.getCharset(), config.getCharset());
 
         getClient(SystemDefaults.SCHEMA).executeCommands(

--- a/src/test/scala/com/wix/mysql/support/InstanceMatchers.scala
+++ b/src/test/scala/com/wix/mysql/support/InstanceMatchers.scala
@@ -32,6 +32,12 @@ trait InstanceMatchers extends Matchers {
         aSelect[String](ds, sql = s"SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA where SCHEMA_NAME = '$onSchema';"))
     }
 
+  def notHaveSchema(onSchema: String): Matcher[EmbeddedMysql] =
+    ===(0) ^^ { mySql: EmbeddedMysql =>
+      val ds = aDataSource(mySql.getConfig, "information_schema")
+      aSelect[java.lang.Integer](ds, sql = s"SELECT COUNT(1) FROM information_schema.SCHEMATA where SCHEMA_NAME = '$onSchema';").toInt
+    }
+
   def haveServerTimezoneMatching(timeZoneId: String): Matcher[EmbeddedMysql] =
     ===(Utils.asHHmmOffset(TimeZone.getTimeZone(timeZoneId))) ^^ { mySql: EmbeddedMysql =>
       val ds = aDataSource(mySql.getConfig, SystemDefaults.SCHEMA)


### PR DESCRIPTION
If one instance is used for several databases, then (in existing design) you need to specify it on creation of EmbeddedMysql. It's not really convenient, because I don't want to couple EmbeddedMysql instance creation and tests initial data.