### PR TITLE
Introduced SqlScriptSource to abstract away File/URL/Script/*Stream...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.wix</groupId>
     <artifactId>wix-embedded-mysql</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Wix Embedded MySql</name>
     <description>Embedded MySql for E2E/IT tests</description>
     <url>https://github.com/wix/wix-embedded-mysql</url>

--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -45,11 +45,11 @@ public class EmbeddedMysql {
         return this.config;
     }
 
-    public void reloadSchema(final String schemaName, final SqlCommandSource... scripts) {
+    public void reloadSchema(final String schemaName, final SqlScriptSource... scripts) {
         reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
     }
 
-    public void reloadSchema(final String schemaName, final List<SqlCommandSource> scripts) {
+    public void reloadSchema(final String schemaName, final List<SqlScriptSource> scripts) {
         reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
     }
 
@@ -103,12 +103,12 @@ public class EmbeddedMysql {
             this.config = config;
         }
 
-        public Builder addSchema(final String name, final SqlCommandSource... scripts) {
+        public Builder addSchema(final String name, final SqlScriptSource... scripts) {
             this.schemas.add(SchemaConfig.aSchemaConfig(name).withScripts(scripts).build());
             return this;
         }
 
-        public Builder addSchema(final String name, final List<SqlCommandSource> scripts) {
+        public Builder addSchema(final String name, final List<SqlScriptSource> scripts) {
             this.schemas.add(SchemaConfig.aSchemaConfig(name).withScripts(scripts).build());
             return this;
         }

--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -10,10 +10,8 @@ import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -47,27 +45,12 @@ public class EmbeddedMysql {
         return this.config;
     }
 
-    /**
-     * @deprecated Use overload with SchemaConfig
-     */
-    public void reloadSchema(final String schemaName, final File... scripts) {
-        List<SqlCommandSource> commands = Collections.emptyList();
-        for (File f : scripts) {
-            commands.add(Sources.fromFile(f));
-        }
-        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(commands).build());
+    public void reloadSchema(final String schemaName, final SqlCommandSource... scripts) {
+        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
     }
 
-    /**
-     * @deprecated Use overload with SchemaConfig
-     */
-    public void reloadSchema(final String schemaName, final List<File> scripts) {
-        List<SqlCommandSource> commands = Collections.emptyList();
-        for (File f : scripts) {
-            commands.add(Sources.fromFile(f));
-        }
-
-        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(commands).build());
+    public void reloadSchema(final String schemaName, final List<SqlCommandSource> scripts) {
+        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
     }
 
     public void reloadSchema(final SchemaConfig config) {

--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -46,14 +47,27 @@ public class EmbeddedMysql {
         return this.config;
     }
 
-    /** @deprecated Use overload with SchemaConfig */
+    /**
+     * @deprecated Use overload with SchemaConfig
+     */
     public void reloadSchema(final String schemaName, final File... scripts) {
-        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
+        List<SqlCommandSource> commands = Collections.emptyList();
+        for (File f : scripts) {
+            commands.add(Sources.fromFile(f));
+        }
+        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(commands).build());
     }
 
-    /** @deprecated Use overload with SchemaConfig */
+    /**
+     * @deprecated Use overload with SchemaConfig
+     */
     public void reloadSchema(final String schemaName, final List<File> scripts) {
-        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(scripts).build());
+        List<SqlCommandSource> commands = Collections.emptyList();
+        for (File f : scripts) {
+            commands.add(Sources.fromFile(f));
+        }
+
+        reloadSchema(SchemaConfig.aSchemaConfig(schemaName).withScripts(commands).build());
     }
 
     public void reloadSchema(final SchemaConfig config) {
@@ -75,7 +89,6 @@ public class EmbeddedMysql {
 
         MysqlClient client = getClient(schema.getName());
         client.executeScripts(schema.getScripts());
-        client.executeCommands(schema.getCommands());
 
         return this;
     }
@@ -107,12 +120,12 @@ public class EmbeddedMysql {
             this.config = config;
         }
 
-        public Builder addSchema(final String name, final File... scripts) {
+        public Builder addSchema(final String name, final SqlCommandSource... scripts) {
             this.schemas.add(SchemaConfig.aSchemaConfig(name).withScripts(scripts).build());
             return this;
         }
 
-        public Builder addSchema(final String name, final List<File> scripts) {
+        public Builder addSchema(final String name, final List<SqlCommandSource> scripts) {
             this.schemas.add(SchemaConfig.aSchemaConfig(name).withScripts(scripts).build());
             return this;
         }

--- a/src/main/java/com/wix/mysql/MysqlClient.java
+++ b/src/main/java/com/wix/mysql/MysqlClient.java
@@ -8,7 +8,6 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.wix.mysql.utils.Utils.isNullOrEmpty;
@@ -27,9 +26,9 @@ class MysqlClient {
         this.schemaName = schemaName;
     }
 
-    void executeScripts(final List<SqlCommandSource> sqls) {
+    void executeScripts(final List<SqlScriptSource> sqls) {
         try {
-            for (SqlCommandSource sql : sqls) {
+            for (SqlScriptSource sql : sqls) {
                 execute(sql.read());
             }
         } catch (IOException e) {

--- a/src/main/java/com/wix/mysql/MysqlClient.java
+++ b/src/main/java/com/wix/mysql/MysqlClient.java
@@ -27,7 +27,7 @@ class MysqlClient {
         this.schemaName = schemaName;
     }
 
-    public void executeScripts(final List<SqlCommandSource> sqls) {
+    void executeScripts(final List<SqlCommandSource> sqls) {
         try {
             for (SqlCommandSource sql : sqls) {
                 execute(sql.read());

--- a/src/main/java/com/wix/mysql/MysqlClient.java
+++ b/src/main/java/com/wix/mysql/MysqlClient.java
@@ -6,9 +6,9 @@ import com.wix.mysql.exceptions.CommandFailedException;
 import de.flapdoodle.embed.process.distribution.Platform;
 import org.apache.commons.io.IOUtils;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.wix.mysql.utils.Utils.isNullOrEmpty;
@@ -27,19 +27,17 @@ class MysqlClient {
         this.schemaName = schemaName;
     }
 
-    public void executeScripts(final List<File> files) {
-        for (File file : files) {
-            execute(format("source %s", file.getAbsolutePath()));
+    public void executeScripts(final List<SqlCommandSource> sqls) {
+        try {
+            for (SqlCommandSource sql : sqls) {
+                execute(sql.read());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
     public void executeCommands(final String... sqls) {
-        for (String sql : sqls) {
-            execute(sql);
-        }
-    }
-
-    public void executeCommands(final List<String> sqls) {
         for (String sql : sqls) {
             execute(sql);
         }

--- a/src/main/java/com/wix/mysql/MysqldProcess.java
+++ b/src/main/java/com/wix/mysql/MysqldProcess.java
@@ -106,6 +106,7 @@ public class MysqldProcess extends AbstractProcess<MysqldConfig, MysqldExecutabl
                     format("--port=%s", getConfig().getPort()),
                     "shutdown"});
 
+            //TODO: make wait with timeout
             retValue = p.waitFor() == 0;
 
             stdErr = new InputStreamReader(p.getErrorStream());

--- a/src/main/java/com/wix/mysql/ScriptResolver.java
+++ b/src/main/java/com/wix/mysql/ScriptResolver.java
@@ -27,7 +27,7 @@ public class ScriptResolver {
      * @param path path to file
      * @return resolved SqlCommandSource
      */
-    public static SqlCommandSource classPathFile(final String path) {
+    public static SqlScriptSource classPathFile(final String path) {
         String normalizedPath = path.startsWith("/") ? path : format("/%s", path);
         URL resource = ScriptResolver.class.getResource(normalizedPath);
 
@@ -44,7 +44,7 @@ public class ScriptResolver {
      * @param pattern ex. 'db/*.sql'
      * @return list of resolved SqlCommandSource objects
      */
-    public static List<SqlCommandSource> classPathFiles(final String pattern) {
+    public static List<SqlScriptSource> classPathFiles(final String pattern) {
         List<File> results;
 
         String[] parts = pattern.split("/");
@@ -71,8 +71,8 @@ public class ScriptResolver {
         }
     }
 
-    private static List<SqlCommandSource> fromFiles(List<File> files) {
-        List<SqlCommandSource> res = new ArrayList<>();
+    private static List<SqlScriptSource> fromFiles(List<File> files) {
+        List<SqlScriptSource> res = new ArrayList<>();
 
         for (File f: files) {
             res.add(Sources.fromFile(f));

--- a/src/main/java/com/wix/mysql/Sources.java
+++ b/src/main/java/com/wix/mysql/Sources.java
@@ -10,19 +10,19 @@ import java.net.URL;
 
 public class Sources {
 
-    public static SqlCommandSource fromString(final String str) {
+    public static SqlScriptSource fromString(final String str) {
         return new StringSource(str);
     }
 
-    public static SqlCommandSource fromFile(final File str) {
+    public static SqlScriptSource fromFile(final File str) {
         return new FileSource(str);
     }
 
-    public static SqlCommandSource fromURL(final URL str) {
+    public static SqlScriptSource fromURL(final URL str) {
         return new URLSource(str);
     }
 
-    private static class StringSource implements SqlCommandSource {
+    private static class StringSource implements SqlScriptSource {
         final String str;
 
         StringSource(final String str) {
@@ -35,7 +35,7 @@ public class Sources {
         }
     }
 
-    private static class FileSource implements SqlCommandSource {
+    private static class FileSource implements SqlScriptSource {
         final File str;
 
         FileSource(final File str) {
@@ -48,7 +48,7 @@ public class Sources {
         }
     }
 
-    private static class URLSource implements SqlCommandSource {
+    private static class URLSource implements SqlScriptSource {
         final URL url;
 
         URLSource(final URL str) {

--- a/src/main/java/com/wix/mysql/Sources.java
+++ b/src/main/java/com/wix/mysql/Sources.java
@@ -1,0 +1,71 @@
+package com.wix.mysql;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class Sources {
+
+    public static SqlCommandSource fromString(final String str) {
+        return new StringSource(str);
+    }
+
+    public static SqlCommandSource fromFile(final File str) {
+        return new FileSource(str);
+    }
+
+    public static SqlCommandSource fromURL(final URL str) {
+        return new URLSource(str);
+    }
+
+    private static class StringSource implements SqlCommandSource {
+        final String str;
+
+        StringSource(final String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String read() {
+            return str;
+        }
+    }
+
+    private static class FileSource implements SqlCommandSource {
+        final File str;
+
+        FileSource(final File str) {
+            this.str = str;
+        }
+
+        @Override
+        public String read() throws IOException {
+            return FileUtils.readFileToString(str);
+        }
+    }
+
+    private static class URLSource implements SqlCommandSource {
+        final URL url;
+
+        URLSource(final URL str) {
+            this.url = str;
+        }
+
+        @Override
+        public String read() throws IOException {
+            InputStream in = url.openStream();
+
+            try {
+                return IOUtils.toString(in);
+            } finally {
+                IOUtils.closeQuietly(in);
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/com/wix/mysql/SqlCommandSource.java
+++ b/src/main/java/com/wix/mysql/SqlCommandSource.java
@@ -1,0 +1,7 @@
+package com.wix.mysql;
+
+import java.io.IOException;
+
+public interface SqlCommandSource {
+    String read() throws IOException;
+}

--- a/src/main/java/com/wix/mysql/SqlScriptSource.java
+++ b/src/main/java/com/wix/mysql/SqlScriptSource.java
@@ -2,6 +2,6 @@ package com.wix.mysql;
 
 import java.io.IOException;
 
-public interface SqlCommandSource {
+public interface SqlScriptSource {
     String read() throws IOException;
 }

--- a/src/main/java/com/wix/mysql/config/SchemaConfig.java
+++ b/src/main/java/com/wix/mysql/config/SchemaConfig.java
@@ -1,22 +1,19 @@
 package com.wix.mysql.config;
 
 import com.wix.mysql.Sources;
-import com.wix.mysql.SqlCommandSource;
+import com.wix.mysql.SqlScriptSource;
 
-import java.io.File;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class SchemaConfig {
 
     private final String name;
     private final Charset charset;
-    private final List<SqlCommandSource> scripts;
+    private final List<SqlScriptSource> scripts;
 
-    private SchemaConfig(String name, Charset charset, List<SqlCommandSource> scripts) {
+    private SchemaConfig(String name, Charset charset, List<SqlScriptSource> scripts) {
         this.name = name;
         this.charset = charset;
         this.scripts = scripts;
@@ -34,7 +31,7 @@ public class SchemaConfig {
         return charset;
     }
 
-    public List<SqlCommandSource> getScripts() {
+    public List<SqlScriptSource> getScripts() {
         return scripts;
     }
 
@@ -42,7 +39,7 @@ public class SchemaConfig {
 
         private final String name;
         private Charset charset;
-        private List<SqlCommandSource> scripts = new ArrayList<>();
+        private List<SqlScriptSource> scripts = new ArrayList<>();
 
         public Builder(final String name) {
             this.name = name;
@@ -53,11 +50,11 @@ public class SchemaConfig {
             return this;
         }
 
-        public Builder withScripts(final SqlCommandSource... scripts) {
+        public Builder withScripts(final SqlScriptSource... scripts) {
             return withScripts(Arrays.asList(scripts));
         }
 
-        public Builder withScripts(final List<SqlCommandSource> scripts) {
+        public Builder withScripts(final List<SqlScriptSource> scripts) {
             this.scripts.addAll(scripts);
             return this;
         }

--- a/src/main/java/com/wix/mysql/config/SchemaConfig.java
+++ b/src/main/java/com/wix/mysql/config/SchemaConfig.java
@@ -1,6 +1,11 @@
 package com.wix.mysql.config;
 
+import com.wix.mysql.Sources;
+import com.wix.mysql.SqlCommandSource;
+
 import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -9,14 +14,12 @@ public class SchemaConfig {
 
     private final String name;
     private final Charset charset;
-    private final List<File> scripts;
-    private final List<String> commands;
+    private final List<SqlCommandSource> scripts;
 
-    private SchemaConfig(String name, Charset charset, List<File> scripts, List<String> commands) {
+    private SchemaConfig(String name, Charset charset, List<SqlCommandSource> scripts) {
         this.name = name;
         this.charset = charset;
         this.scripts = scripts;
-        this.commands = commands;
     }
 
     public static Builder aSchemaConfig(final String name) {
@@ -31,20 +34,15 @@ public class SchemaConfig {
         return charset;
     }
 
-    public List<File> getScripts() {
+    public List<SqlCommandSource> getScripts() {
         return scripts;
-    }
-
-    public List<String> getCommands() {
-        return commands;
     }
 
     public static class Builder {
 
         private final String name;
         private Charset charset;
-        private List<File> scripts = Collections.emptyList();
-        private List<String> commands = Collections.emptyList();
+        private List<SqlCommandSource> scripts = new ArrayList<>();
 
         public Builder(final String name) {
             this.name = name;
@@ -55,12 +53,12 @@ public class SchemaConfig {
             return this;
         }
 
-        public Builder withScripts(final File... scripts) {
+        public Builder withScripts(final SqlCommandSource... scripts) {
             return withScripts(Arrays.asList(scripts));
         }
 
-        public Builder withScripts(final List<File> scripts) {
-            this.scripts = scripts;
+        public Builder withScripts(final List<SqlCommandSource> scripts) {
+            this.scripts.addAll(scripts);
             return this;
         }
 
@@ -69,12 +67,14 @@ public class SchemaConfig {
         }
 
         public Builder withCommands(final List<String> commands) {
-            this.commands = commands;
+            for (String cmd: commands) {
+                this.scripts.add(Sources.fromString(cmd));
+            }
             return this;
         }
 
         public SchemaConfig build() {
-            return new SchemaConfig(name, charset, scripts, commands);
+            return new SchemaConfig(name, charset, scripts);
         }
     }
 }

--- a/src/test/scala/com/wix/mysql/SchemaConfigTest.scala
+++ b/src/test/scala/com/wix/mysql/SchemaConfigTest.scala
@@ -29,14 +29,14 @@ class SchemaConfigTest extends SpecWithJUnit {
       schemaConfig.getCharset mustEqual charset
     }
 
-    "build with Files" in {
-      val files = Seq(new File("/some"), new File("/some/other"))
+    "build with sources" in {
+      val sources = Seq(Sources.fromFile(new File("/some")), Sources.fromFile(new File("/some/other")))
 
       val schemaConfig = aSchemaConfig("aschema")
-        .withScripts(files)
+        .withScripts(sources)
         .build
 
-      schemaConfig.getScripts.toSeq mustEqual files
+      schemaConfig.getScripts.toSeq mustEqual sources
     }
   }
 }

--- a/src/test/scala/com/wix/mysql/ScriptResolverTest.scala
+++ b/src/test/scala/com/wix/mysql/ScriptResolverTest.scala
@@ -9,16 +9,19 @@ import org.specs2.mutable.SpecWithJUnit
 import scala.collection.convert.decorateAsScala._
 
 class ScriptResolverTest extends SpecWithJUnit with FileMatchers {
+  val contentsOf001Init = "create table t1"
+  val contentsOf002Update = "create table t2"
+  val contentsOf003Update = "create table t3"
 
   //TODO: add additional variations for sorting, etc.
   "ScriptResolver.classPathFile" should {
 
     "resolve a single classPath file" in {
-      classPathFile("/db/001_init.sql") must beAFile
+      classPathFile("/db/001_init.sql").read() must startWith(contentsOf001Init)
     }
 
     "resolve a single classPath file without preceding '/'" in {
-      classPathFile("db/001_init.sql") must beAFile
+      classPathFile("db/001_init.sql").read() must startWith(contentsOf001Init)
     }
 
     "throw a ScriptResolutionException for a non-existent script" in {
@@ -29,17 +32,17 @@ class ScriptResolverTest extends SpecWithJUnit with FileMatchers {
   "ScriptResolver.classPathFiles" should {
 
     "resolve multiple classPath files" in {
-      classPathFiles("/db/*.sql").asScala mustEqual Seq(
-        aFile("/db/001_init.sql"),
-        aFile("/db/002_update1.sql"),
-        aFile("/db/003_update2.sql"))
+      classPathFiles("/db/*.sql").asScala.map(_.read) must contain(exactly(
+        startWith(contentsOf001Init),
+        startWith(contentsOf002Update),
+        startWith(contentsOf003Update))).inOrder
     }
 
     "resolve multiple classPath files without preceding '/'" in {
-      classPathFiles("db/*.sql").asScala mustEqual Seq(
-        aFile("/db/001_init.sql"),
-        aFile("/db/002_update1.sql"),
-        aFile("/db/003_update2.sql"))
+      classPathFiles("/db/*.sql").asScala.map(_.read) must contain(exactly(
+        startWith(contentsOf001Init),
+        startWith(contentsOf002Update),
+        startWith(contentsOf003Update))).inOrder
     }
 
     "throw a ScriptResolutionException if no classPathFiles are found" in {

--- a/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
+++ b/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
@@ -7,7 +7,7 @@ import ch.qos.logback.classic.Level.INFO
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.core.read.ListAppender
-import com.wix.mysql.{EmbeddedMysql, Sources, SqlCommandSource}
+import com.wix.mysql.{EmbeddedMysql, Sources, SqlScriptSource}
 import com.wix.mysql.config.MysqldConfig
 import org.apache.commons.dbcp2.BasicDataSource
 import org.slf4j.LoggerFactory
@@ -79,7 +79,7 @@ trait JdbcSupport {
   def anUpdate(onSchema: String, sql: String): Unit =
     aJdbcTemplate(forSchema = onSchema).execute(sql)
 
-  def aMigrationWith(sql: String): SqlCommandSource = Sources.fromFile(createTempFile(sql))
+  def aMigrationWith(sql: String): SqlScriptSource = Sources.fromFile(createTempFile(sql))
 
   def beSuccessful = not(throwAn[Exception])
 

--- a/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
+++ b/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
@@ -7,7 +7,7 @@ import ch.qos.logback.classic.Level.INFO
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.core.read.ListAppender
-import com.wix.mysql.EmbeddedMysql
+import com.wix.mysql.{EmbeddedMysql, Sources, SqlCommandSource}
 import com.wix.mysql.config.MysqldConfig
 import org.apache.commons.dbcp2.BasicDataSource
 import org.slf4j.LoggerFactory
@@ -79,7 +79,7 @@ trait JdbcSupport {
   def anUpdate(onSchema: String, sql: String): Unit =
     aJdbcTemplate(forSchema = onSchema).execute(sql)
 
-  def aMigrationWith(sql: String): File = createTempFile(sql)
+  def aMigrationWith(sql: String): SqlCommandSource = Sources.fromFile(createTempFile(sql))
 
   def beSuccessful = not(throwAn[Exception])
 


### PR DESCRIPTION
Reason: I want to add capabilities to load migration scripts from .jars (other module in multi-module projects) and I have 2 possibilities:
 - add another overload to SchemaConfig/EmbeddedMysql.Builder with type URL/InputStream and new name (withMigrations);
 - do what I did and allow to add arbitrary sources in future;

I did not feel comfortable with using InputStream/URL ? as another requirement might come-up and I'm screwed again (exausted with* names), so decided to rollout SqlCommandSource interface and helpers to build it from String/File/URL.

But the main question for me is:
 - should I introduce new operations (ScriptConfig.withMigrations(List<SqlCommandSource> sources)) and deprecate others + SqlCommandResolver.classPathFiles - no-breaking api change;
 - do current change (I found 1 obvious client in wix that would break) and just up major version signifying a breaking api change.

#1 is more javaish, #2 is cleaner (less migrations, less deprecated code, etc.). @ittaiz @hugebdu - which way would you go? Note that I have external clients as well (4-5 OSS on github, but it seems there would be no impact to them).

