### PR TITLE
Add support for running multiple instances in parallel in same process

### DIFF
--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.wix.mysql.config.MysqldConfig.SystemDefaults.SCHEMA;
 import static com.wix.mysql.utils.Utils.or;
@@ -21,6 +22,7 @@ import static java.lang.String.format;
 
 public class EmbeddedMysql {
     private final static Logger logger = LoggerFactory.getLogger(EmbeddedMysql.class);
+    private static final ReentrantLock lock = new ReentrantLock();
 
     protected final MysqldConfig config;
     protected final MysqldExecutable executable;
@@ -30,7 +32,13 @@ public class EmbeddedMysql {
         logger.info("Preparing EmbeddedMysql version '{}'...", config.getVersion());
         this.config = config;
         IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(config.getVersion()).build();
-        this.executable = new MysqldStarter(runtimeConfig).prepare(config);
+
+        lock.lock();
+        try {
+            this.executable = new MysqldStarter(runtimeConfig).prepare(config);
+        } finally {
+            lock.unlock();
+        }
 
         try {
             executable.start();

--- a/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -22,7 +22,7 @@ import static java.lang.String.format;
 
 public class EmbeddedMysql {
     private final static Logger logger = LoggerFactory.getLogger(EmbeddedMysql.class);
-    private static final ReentrantLock lock = new ReentrantLock();
+    private static final ReentrantLock localRepository = new ReentrantLock();
 
     protected final MysqldConfig config;
     protected final MysqldExecutable executable;
@@ -32,12 +32,13 @@ public class EmbeddedMysql {
         logger.info("Preparing EmbeddedMysql version '{}'...", config.getVersion());
         this.config = config;
         IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(config.getVersion()).build();
+        MysqldStarter mysqldStarter = new MysqldStarter(runtimeConfig);
 
-        lock.lock();
+        localRepository.lock();
         try {
-            this.executable = new MysqldStarter(runtimeConfig).prepare(config);
+            this.executable = mysqldStarter.prepare(config);
         } finally {
-            lock.unlock();
+            localRepository.unlock();
         }
 
         try {

--- a/src/main/java/com/wix/mysql/config/RuntimeConfigBuilder.java
+++ b/src/main/java/com/wix/mysql/config/RuntimeConfigBuilder.java
@@ -26,7 +26,7 @@ public class RuntimeConfigBuilder extends de.flapdoodle.embed.process.config.Run
     }
 
     public RuntimeConfigBuilder defaults(Version version) {
-        String directoryName = String.format("mysql-%s-%s", version.getMajorVersion(), UUID.randomUUID().toString());
+        String directoryName = String.format("mysql-%s-%s", version.getMajorVersion(), UUID.randomUUID());
         defaults().artifactStore().setDefault(artifactStoreBuilderFor(directoryName));
 
         return this;

--- a/src/main/java/com/wix/mysql/config/RuntimeConfigBuilder.java
+++ b/src/main/java/com/wix/mysql/config/RuntimeConfigBuilder.java
@@ -9,6 +9,8 @@ import de.flapdoodle.embed.process.store.IArtifactStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
+
 import static de.flapdoodle.embed.process.io.Processors.logTo;
 import static de.flapdoodle.embed.process.io.Slf4jLevel.DEBUG;
 
@@ -24,7 +26,7 @@ public class RuntimeConfigBuilder extends de.flapdoodle.embed.process.config.Run
     }
 
     public RuntimeConfigBuilder defaults(Version version) {
-        String directoryName = String.format("mysql-%s", version.getMajorVersion());
+        String directoryName = String.format("mysql-%s-%s", version.getMajorVersion(), UUID.randomUUID().toString());
         defaults().artifactStore().setDefault(artifactStoreBuilderFor(directoryName));
 
         return this;

--- a/src/main/java/com/wix/mysql/distribution/service/CatchAllCommandEmitter.java
+++ b/src/main/java/com/wix/mysql/distribution/service/CatchAllCommandEmitter.java
@@ -8,6 +8,7 @@ import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -31,7 +32,7 @@ public class CatchAllCommandEmitter implements CommandEmitter {
                 format("--plugin-dir=%s/lib/plugin", baseDir),
                 format("--lc-messages-dir=%s/share", baseDir),
                 format("--port=%s", config.getPort()),
-                format("--socket=%s", sockFile(exe)),
+                format("--socket=%s", sockFile()),
                 "--console",
                 format("--character-set-server=%s", config.getCharset().getCharset()),
                 format("--collation-server=%s", config.getCharset().getCollate()),
@@ -50,9 +51,7 @@ public class CatchAllCommandEmitter implements CommandEmitter {
      * This is due to possible problems with existing mysql installation and apparmor profiles
      * in linuxes.
      */
-    private String sockFile(IExtractedFileSet exe) throws IOException {
-        String sysTempDir = System.getProperty("java.io.tmpdir");
-        String sockFile = format("%s.sock", exe.baseDir().getName());
-        return new File(sysTempDir, sockFile).getAbsolutePath();
+    private String sockFile() throws IOException {
+        return Files.createTempFile(null, ".sock").toString();
     }
 }

--- a/src/main/java/com/wix/mysql/distribution/service/CatchAllCommandEmitter.java
+++ b/src/main/java/com/wix/mysql/distribution/service/CatchAllCommandEmitter.java
@@ -31,10 +31,28 @@ public class CatchAllCommandEmitter implements CommandEmitter {
                 format("--plugin-dir=%s/lib/plugin", baseDir),
                 format("--lc-messages-dir=%s/share", baseDir),
                 format("--port=%s", config.getPort()),
+                format("--socket=%s", sockFile(exe)),
                 "--console",
                 format("--character-set-server=%s", config.getCharset().getCharset()),
                 format("--collation-server=%s", config.getCharset().getCollate()),
                 format("--default-time-zone=%s", Utils.asHHmmOffset(config.getTimeZone())));
 
+    }
+
+    /**
+     * Helper for getting stable sock classPathFile. Saving to local instance variable on service start does not work due
+     * to the way flapdoodle process library works - it does all init in {@link de.flapdoodle.embed.process.runtime.AbstractProcess} and instance of
+     * {@link com.wix.mysql.MysqldProcess} is not yet present, so vars are not initialized.
+     * This algo gives stable sock classPathFile based on single executeCommands profile, but can leave trash sock classPathFiles in tmp dir.
+     * <p>
+     * Notes:
+     * .sock classPathFile needs to be in system temp dir and not in ex. target/...
+     * This is due to possible problems with existing mysql installation and apparmor profiles
+     * in linuxes.
+     */
+    private String sockFile(IExtractedFileSet exe) throws IOException {
+        String sysTempDir = System.getProperty("java.io.tmpdir");
+        String sockFile = format("%s.sock", exe.baseDir().getName());
+        return new File(sysTempDir, sockFile).getAbsolutePath();
     }
 }

--- a/src/test/scala/com/wix/mysql/MysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/MysqlTest.scala
@@ -8,7 +8,7 @@ import com.wix.mysql.support.IntegrationTest
 class MysqlTest extends IntegrationTest {
 
   "mysql should emit exception info with message from 'mysql' command output'" in {
-    val mysqld = withStop(anEmbeddedMysql(v5_6_latest).start)
+    val mysqld = start(anEmbeddedMysql(v5_6_latest))
     val mysql = new MysqlClient(mysqld.getConfig, mysqld.executable, "information_schema")
 
     mysql.executeCommands("sele qwe from zz;") must throwA[CommandFailedException].like {

--- a/src/test/scala/com/wix/mysql/MysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/MysqlTest.scala
@@ -8,7 +8,7 @@ import com.wix.mysql.support.IntegrationTest
 class MysqlTest extends IntegrationTest {
 
   "mysql should emit exception info with message from 'mysql' command output'" in {
-    mysqld = anEmbeddedMysql(v5_6_latest).start()
+    val mysqld = withStop(anEmbeddedMysql(v5_6_latest).start)
     val mysql = new MysqlClient(mysqld.getConfig, mysqld.executable, "information_schema")
 
     mysql.executeCommands("sele qwe from zz;") must throwA[CommandFailedException].like {

--- a/src/test/scala/com/wix/mysql/ParallelEmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/ParallelEmbeddedMysqlTest.scala
@@ -1,0 +1,50 @@
+package com.wix.mysql
+
+import java.util.UUID
+
+import com.wix.mysql.EmbeddedMysql._
+import com.wix.mysql.config.MysqldConfig.aMysqldConfig
+import com.wix.mysql.distribution.Version
+import com.wix.mysql.support.IntegrationTest
+import de.flapdoodle.embed.process.io.directories.UserHome
+import org.apache.commons.io.FileUtils
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class ParallelEmbeddedMysqlTest extends IntegrationTest {
+
+  "EmbeddedMysql instance" should {
+
+    "run 2 instances in parallel" in {
+      withCleanRepo {
+        val promisedMysql1 = runMysql(onPort = 3310)
+        val promisedMysql2 = runMysql(onPort = 3311)
+
+        Await.result(promisedMysql1, 15 minutes)
+        Await.result(promisedMysql2, 15 minutes)
+
+        1 mustEqual 1
+      }
+    }
+  }
+
+  def runMysql(onPort: Int) = Future {
+      val config1 = aMysqldConfig(Version.v5_7_latest).withPort(onPort).build
+      val mysqld1 = withStop(anEmbeddedMysql(config1).start)
+    }
+
+  def withCleanRepo[T](f: => T): T = {
+    val repository = new UserHome(".embedmysql").asFile()
+    val backupFolder = new UserHome(s".embedmysql${UUID.randomUUID().toString}").asFile()
+    FileUtils.moveDirectory(repository, backupFolder)
+    try {
+      f
+    } finally {
+      println("delete directory")
+      FileUtils.deleteDirectory(repository)
+      FileUtils.moveDirectory(backupFolder, repository)
+    }
+  }
+}

--- a/src/test/scala/com/wix/mysql/ParallelEmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/ParallelEmbeddedMysqlTest.scala
@@ -22,7 +22,7 @@ class ParallelEmbeddedMysqlTest extends IntegrationTest {
 
   def runMysql(onPort: Int) = Future {
     val config = aMysqldConfig(Version.v5_7_latest).withPort(onPort).build
-    val mysqld = withStop(anEmbeddedMysql(config).start)
+    val mysqld = start(anEmbeddedMysql(config))
 
     mysqld must beAvailableOn(onPort, "auser", "sa", SystemDefaults.SCHEMA)
   }

--- a/src/test/scala/com/wix/mysql/SupportedVersionsTest.scala
+++ b/src/test/scala/com/wix/mysql/SupportedVersionsTest.scala
@@ -18,9 +18,9 @@ class SupportedVersionsTest extends IntegrationTest {
     s"$version should work on ${System.getProperty("os.name")}" in new Context {
       val config = aMysqldConfig(version).build
 
-      mysqld = anEmbeddedMysql(config)
+      val mysqld = withStop(anEmbeddedMysql(config)
         .addSchema("aschema")
-        .start
+        .start)
 
       mysqld must beAvailableOn(config, "aschema")
 

--- a/src/test/scala/com/wix/mysql/SupportedVersionsTest.scala
+++ b/src/test/scala/com/wix/mysql/SupportedVersionsTest.scala
@@ -18,9 +18,7 @@ class SupportedVersionsTest extends IntegrationTest {
     s"$version should work on ${System.getProperty("os.name")}" in new Context {
       val config = aMysqldConfig(version).build
 
-      val mysqld = withStop(anEmbeddedMysql(config)
-        .addSchema("aschema")
-        .start)
+      val mysqld = start(anEmbeddedMysql(config).addSchema("aschema"))
 
       mysqld must beAvailableOn(config, "aschema")
 

--- a/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
+++ b/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
@@ -33,10 +33,12 @@ abstract class IntegrationTest extends SpecWithJUnit with BeforeAfterEach
   def before: Any = mysqldInstances = Seq()
   def after: Any = mysqldInstances.foreach(_.stop)
 
-  def withStop(mysqld: EmbeddedMysql): EmbeddedMysql = {
-    mysqldInstances = mysqldInstances :+ mysqld
-    mysqld
+  def start(mysqld: EmbeddedMysql.Builder): EmbeddedMysql = {
+    val instance = mysqld.start
+    mysqldInstances = mysqldInstances :+ instance
+    instance
   }
+
 
   def aLogFor(app: String): Iterable[String] = {
     val appender: ListAppender[ILoggingEvent] = new ListAppender[ILoggingEvent]
@@ -58,7 +60,7 @@ abstract class IntegrationTest extends SpecWithJUnit with BeforeAfterEach
 
   def withCleanRepo[T](f: => T): T = {
     val repository = new UserHome(".embedmysql").asFile
-    val backupFolder = new UserHome(s".embedmysql-${UUID.randomUUID().toString}").asFile
+    val backupFolder = new UserHome(s".embedmysql-${UUID.randomUUID()}").asFile
     moveDirectory(repository, backupFolder)
 
     try {

--- a/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
+++ b/src/test/scala/com/wix/mysql/support/IntegrationTest.scala
@@ -30,14 +30,8 @@ abstract class IntegrationTest extends SpecWithJUnit with BeforeAfterEach
   var mysqldInstances: Seq[EmbeddedMysql] = Seq()
   val log = getLogger(this.getClass)
 
-  def before: Any = {
-    println("before")
-    mysqldInstances = Seq()
-  }
-  def after: Any = {
-    println("after")
-    mysqldInstances.foreach(_.stop())
-  }
+  def before: Any = mysqldInstances = Seq()
+  def after: Any = mysqldInstances.foreach(_.stop)
 
   def withStop(mysqld: EmbeddedMysql): EmbeddedMysql = {
     mysqldInstances = mysqldInstances :+ mysqld


### PR DESCRIPTION
fixes #55 

This does not solve an issue if you would run your test-runner ir a forked process mode, as there is no locking for download/extract which might fall into concurrency issues, but this is a quick-win and covers most painful situation:
 - running multiple instances in parallel;
 - not reusing tmp folder and using unique one every time, as this can give flaky failures in setups where build artefacts are being cached (optimized ci).
