### PR TITLE
Add latest MySQL 5.5/5.6/5.7 versions and macOS Sierra compatibility

### DIFF
--- a/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/src/main/java/com/wix/mysql/distribution/Version.java
@@ -1,49 +1,94 @@
 package com.wix.mysql.distribution;
 
+import static java.lang.String.format;
+
 import com.wix.mysql.exceptions.UnsupportedPlatformException;
 import com.wix.mysql.utils.Utils;
 import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.process.distribution.Platform;
-
 import java.util.Arrays;
 import java.util.List;
 
-import static java.lang.String.format;
-
 public enum Version implements IVersion {
 
-    v5_5_40("5.5", "40", Platform.Linux, Platform.OS_X),
-    v5_6_21("5.6", "21"),
-    v5_6_22("5.6", "22"),
-    v5_6_23("5.6", "23"),
-    v5_6_24("5.6", "24"),
-    v5_6_latest(v5_6_24),
-    v5_7_10("5.7", "10"),
-    v5_7_13("5.7", "10"),
-    v5_7_latest(v5_7_13);
+    v5_5_40("5.5", 40, MacOsVersion.v10_6, Platform.Linux, Platform.OS_X),
+    v5_5_41("5.5", 41, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_42("5.5", 42, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_43("5.5", 43, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_44("5.5", 44, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_45("5.5", 45, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_46("5.5", 46, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_47("5.5", 47, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_48("5.5", 48, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_49("5.5", 49, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_50("5.5", 50, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_51("5.5", 51, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_52("5.5", 52, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_latest(v5_5_52),
+    v5_6_21("5.6", 21, MacOsVersion.v10_9),
+    v5_6_22("5.6", 22, MacOsVersion.v10_9),
+    v5_6_23("5.6", 23, MacOsVersion.v10_9),
+    v5_6_24("5.6", 24, MacOsVersion.v10_9),
+    v5_6_25("5.6", 25, MacOsVersion.v10_9),
+    v5_6_26("5.6", 26, MacOsVersion.v10_9),
+    v5_6_27("5.6", 27, MacOsVersion.v10_9),
+    v5_6_28("5.6", 28, MacOsVersion.v10_10),
+    v5_6_29("5.6", 29, MacOsVersion.v10_10),
+    v5_6_30("5.6", 30, MacOsVersion.v10_11),
+    v5_6_31("5.6", 31, MacOsVersion.v10_11),
+    v5_6_32("5.6", 32, MacOsVersion.v10_11),
+    v5_6_33("5.6", 33, MacOsVersion.v10_11),
+    v5_6_latest(v5_6_33),
+    v5_7_10("5.7", 10, MacOsVersion.v10_10),
+    v5_7_11("5.7", 11, MacOsVersion.v10_10),
+    v5_7_12("5.7", 12, MacOsVersion.v10_11),
+    v5_7_13("5.7", 13, MacOsVersion.v10_11),
+    v5_7_14("5.7", 14, MacOsVersion.v10_11),
+    v5_7_15("5.7", 15, MacOsVersion.v10_11),
+    v5_7_latest(v5_7_15);
+
+    private enum MacOsVersion {
+        v10_6, v10_7, v10_8, v10_9, v10_10, v10_11;
+
+        @Override
+        public String toString() {
+            return name().substring(1).replace('_', '.');
+        }
+    }
 
     private final String majorVersion;
-    private final String minorVersion;
+    private final int minorVersion;
+    private final MacOsVersion macOsVersion;
     private final List<Platform> supportedPlatforms;
 
-    Version(String majorVersion, String minorVersion, Platform... supportedPlatforms) {
+    Version(String majorVersion, int minorVersion, MacOsVersion macOsVersion, Platform... supportedPlatforms) {
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;
+        this.macOsVersion = macOsVersion;
         this.supportedPlatforms = Arrays.asList(supportedPlatforms);
     }
 
-    Version(String majorVersion, String minorVersion) {
-        this(majorVersion, minorVersion, Platform.Linux, Platform.Windows, Platform.OS_X);
+    Version(String majorVersion, int minorVersion, MacOsVersion macOsVersion) {
+        this(majorVersion, minorVersion, macOsVersion, Platform.Linux, Platform.Windows, Platform.OS_X);
     }
 
     Version(Version other) {
         this.majorVersion = other.majorVersion;
         this.minorVersion = other.minorVersion;
+        this.macOsVersion = other.macOsVersion;
         this.supportedPlatforms = other.supportedPlatforms;
     }
 
     public boolean supportsCurrentPlatform() {
-        return supportedPlatforms.contains(currentPlatform());
+        return supportedPlatforms.contains(currentPlatform()) && (!isMacOsSierra() || worksOnMacOsSierra());
+    }
+
+    private boolean isMacOsSierra() {
+        return currentPlatform() == Platform.OS_X && System.getProperty("os.version").startsWith("10.12");
+    }
+
+    private boolean worksOnMacOsSierra() {
+        return !majorVersion.equals("5.7") || minorVersion >= 15;
     }
 
     @Override
@@ -54,7 +99,7 @@ public enum Version implements IVersion {
             case Windows:
                 return format("%s/mysql-%s.%s", path(), majorVersion, minorVersion);
             case OS_X:
-                return format("%s/mysql-%s.%s-osx%s", path(), majorVersion, minorVersion, osVersion());
+                return format("%s/mysql-%s.%s-osx%s", path(), majorVersion, minorVersion, macOsVersion);
             case Linux:
                 return format("%s/mysql-%s.%s-%s", path(), majorVersion, minorVersion, gcLibVersion());
             default:
@@ -65,15 +110,6 @@ public enum Version implements IVersion {
     @Override
     public String toString() {
         return String.format("Version %s.%s", majorVersion, minorVersion);
-    }
-
-    private String osVersion() {
-        if (majorVersion.equals("5.6") || majorVersion.equals("5.7"))
-            //TODO: 5.6 has support for 10.8 as well. Maybe we should be smarter about it?
-            return "10.9";
-        if (majorVersion.equals("5.5"))
-            return "10.6";
-        throw new UnsupportedOperationException();
     }
 
     private String gcLibVersion() {


### PR DESCRIPTION
This PR adds support for latest minor releases for all three active major MySQL versions (5.5, 5.6 and 5.7). Also, it makes the build compatible with recently released macOS Sierra. MySQL 5.7 had a [known](http://devmarketer.io/learn/do-not-install-mysql-macos-sierra-how-to-fix/) [issue](https://github.com/Homebrew/homebrew-core/issues/4720) on Sierra where the initialisation process hangs on shutdown, fixed in [5.7.15](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-15.html):
> kevent statement timer subsystem deinitialization was revised to avoid a mysqld hang during shutdown on OS X 10.12. (Bug #23744004, Bug #82097).