### PR TITLE
Allow running MySQL as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 language: java
-script: mvn -q -B clean verify
+script: $CMD
+
+env:
+  global:
+    - CMD='mvn -q -B clean verify'
 
 before_install:
 # os x - workaround for JAVA_HOME not set and mvn missing
@@ -21,6 +25,10 @@ matrix:
           jdk: oraclejdk8
         - os: osx
           language: java
+        - os: linux
+          sudo: required
+          jdk: openjdk7
+          env: CMD='sudo -E /usr/local/maven-3.2.5/bin/mvn -q -B clean verify'
 
 notifications:
   email:

--- a/src/main/java/com/wix/mysql/distribution/service/CatchAllCommandEmitter.java
+++ b/src/main/java/com/wix/mysql/distribution/service/CatchAllCommandEmitter.java
@@ -33,6 +33,7 @@ public class CatchAllCommandEmitter implements CommandEmitter {
                 format("--lc-messages-dir=%s/share", baseDir),
                 format("--port=%s", config.getPort()),
                 format("--socket=%s", sockFile()),
+                format("--user=%s", System.getProperty("user.name")),
                 "--console",
                 format("--character-set-server=%s", config.getCharset().getCharset()),
                 format("--collation-server=%s", config.getCharset().getCollate()),


### PR DESCRIPTION
This PR tries to address #25 and allow running MySQL as root, which is particularly useful when running builds in Docker containers, for example in Bitbucket Pipelines. When not running as root this has no impact - MySQL will be launched under the current user as usually.