### PR TITLE
Add latest MySQL 5.5/5.6/5.7 versions

### DIFF
--- a/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/src/main/java/com/wix/mysql/distribution/Version.java
@@ -11,21 +11,27 @@ import java.util.List;
 
 public enum Version implements IVersion {
 
+    v5_5_40("5.5", 40, MacOsVersion.v10_6, Platform.Linux, Platform.OS_X),
     v5_5_50("5.5", 50, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
     v5_5_51("5.5", 51, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
     v5_5_52("5.5", 52, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
     v5_5_latest(v5_5_52),
+    v5_6_21("5.6", 21, MacOsVersion.v10_9),
+    v5_6_22("5.6", 22, MacOsVersion.v10_9),
+    v5_6_23("5.6", 23, MacOsVersion.v10_9),
+    v5_6_24("5.6", 24, MacOsVersion.v10_9),
     v5_6_31("5.6", 31, MacOsVersion.v10_11),
     v5_6_32("5.6", 32, MacOsVersion.v10_11),
     v5_6_33("5.6", 33, MacOsVersion.v10_11),
     v5_6_latest(v5_6_33),
+    v5_7_10("5.7", 10, MacOsVersion.v10_10),
     v5_7_13("5.7", 13, MacOsVersion.v10_11),
     v5_7_14("5.7", 14, MacOsVersion.v10_11),
     v5_7_15("5.7", 15, MacOsVersion.v10_11),
     v5_7_latest(v5_7_15);
 
     private enum MacOsVersion {
-        v10_6, v10_7, v10_8, v10_9, v10_10, v10_11;
+        v10_6, v10_9, v10_10, v10_11;
 
         @Override
         public String toString() {

--- a/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/src/main/java/com/wix/mysql/distribution/Version.java
@@ -1,49 +1,71 @@
 package com.wix.mysql.distribution;
 
+import static java.lang.String.format;
+
 import com.wix.mysql.exceptions.UnsupportedPlatformException;
 import com.wix.mysql.utils.Utils;
 import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.process.distribution.Platform;
-
 import java.util.Arrays;
 import java.util.List;
 
-import static java.lang.String.format;
-
 public enum Version implements IVersion {
 
-    v5_5_40("5.5", "40", Platform.Linux, Platform.OS_X),
-    v5_6_21("5.6", "21"),
-    v5_6_22("5.6", "22"),
-    v5_6_23("5.6", "23"),
-    v5_6_24("5.6", "24"),
-    v5_6_latest(v5_6_24),
-    v5_7_10("5.7", "10"),
-    v5_7_13("5.7", "10"),
-    v5_7_latest(v5_7_13);
+    v5_5_50("5.5", 50, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_51("5.5", 51, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_52("5.5", 52, MacOsVersion.v10_9, Platform.Linux, Platform.OS_X),
+    v5_5_latest(v5_5_52),
+    v5_6_31("5.6", 31, MacOsVersion.v10_11),
+    v5_6_32("5.6", 32, MacOsVersion.v10_11),
+    v5_6_33("5.6", 33, MacOsVersion.v10_11),
+    v5_6_latest(v5_6_33),
+    v5_7_13("5.7", 13, MacOsVersion.v10_11),
+    v5_7_14("5.7", 14, MacOsVersion.v10_11),
+    v5_7_15("5.7", 15, MacOsVersion.v10_11),
+    v5_7_latest(v5_7_15);
+
+    private enum MacOsVersion {
+        v10_6, v10_7, v10_8, v10_9, v10_10, v10_11;
+
+        @Override
+        public String toString() {
+            return name().substring(1).replace('_', '.');
+        }
+    }
 
     private final String majorVersion;
-    private final String minorVersion;
+    private final int minorVersion;
+    private final MacOsVersion macOsVersion;
     private final List<Platform> supportedPlatforms;
 
-    Version(String majorVersion, String minorVersion, Platform... supportedPlatforms) {
+    Version(String majorVersion, int minorVersion, MacOsVersion macOsVersion, Platform... supportedPlatforms) {
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;
+        this.macOsVersion = macOsVersion;
         this.supportedPlatforms = Arrays.asList(supportedPlatforms);
     }
 
-    Version(String majorVersion, String minorVersion) {
-        this(majorVersion, minorVersion, Platform.Linux, Platform.Windows, Platform.OS_X);
+    Version(String majorVersion, int minorVersion, MacOsVersion macOsVersion) {
+        this(majorVersion, minorVersion, macOsVersion, Platform.Linux, Platform.Windows, Platform.OS_X);
     }
 
     Version(Version other) {
         this.majorVersion = other.majorVersion;
         this.minorVersion = other.minorVersion;
+        this.macOsVersion = other.macOsVersion;
         this.supportedPlatforms = other.supportedPlatforms;
     }
 
     public boolean supportsCurrentPlatform() {
-        return supportedPlatforms.contains(currentPlatform());
+        return supportedPlatforms.contains(currentPlatform()) && (!isMacOsSierra() || worksOnMacOsSierra());
+    }
+
+    private boolean isMacOsSierra() {
+        return currentPlatform() == Platform.OS_X && System.getProperty("os.version").startsWith("10.12");
+    }
+
+    private boolean worksOnMacOsSierra() {
+        return !majorVersion.equals("5.7") || minorVersion >= 15;
     }
 
     @Override
@@ -54,7 +76,7 @@ public enum Version implements IVersion {
             case Windows:
                 return format("%s/mysql-%s.%s", path(), majorVersion, minorVersion);
             case OS_X:
-                return format("%s/mysql-%s.%s-osx%s", path(), majorVersion, minorVersion, osVersion());
+                return format("%s/mysql-%s.%s-osx%s", path(), majorVersion, minorVersion, macOsVersion);
             case Linux:
                 return format("%s/mysql-%s.%s-%s", path(), majorVersion, minorVersion, gcLibVersion());
             default:
@@ -65,15 +87,6 @@ public enum Version implements IVersion {
     @Override
     public String toString() {
         return String.format("Version %s.%s", majorVersion, minorVersion);
-    }
-
-    private String osVersion() {
-        if (majorVersion.equals("5.6") || majorVersion.equals("5.7"))
-            //TODO: 5.6 has support for 10.8 as well. Maybe we should be smarter about it?
-            return "10.9";
-        if (majorVersion.equals("5.5"))
-            return "10.6";
-        throw new UnsupportedOperationException();
     }
 
     private String gcLibVersion() {

--- a/src/test/scala/com/wix/mysql/JavaUsageExamplesTest.java
+++ b/src/test/scala/com/wix/mysql/JavaUsageExamplesTest.java
@@ -14,8 +14,8 @@ import static com.wix.mysql.config.Charset.LATIN1;
 import static com.wix.mysql.config.Charset.UTF8;
 import static com.wix.mysql.config.MysqldConfig.aMysqldConfig;
 import static com.wix.mysql.config.SchemaConfig.aSchemaConfig;
-import static com.wix.mysql.distribution.Version.v5_6_23;
 import static com.wix.mysql.distribution.Version.v5_6_latest;
+import static com.wix.mysql.distribution.Version.v5_7_latest;
 
 @Ignore
 public class JavaUsageExamplesTest {
@@ -44,7 +44,7 @@ public class JavaUsageExamplesTest {
 
     @Test
     public void mysqldConfigAndMultipleSchemas() {
-        MysqldConfig config = aMysqldConfig(v5_6_23)
+        MysqldConfig config = aMysqldConfig(v5_7_latest)
                 .withCharset(UTF8)
                 .withPort(2215)
                 .withUser("differentUser", "anotherPasword")

--- a/src/test/scala/com/wix/mysql/distribution/VersionTest.scala
+++ b/src/test/scala/com/wix/mysql/distribution/VersionTest.scala
@@ -16,34 +16,34 @@ class VersionTest extends SpecWithJUnit with AroundEach {
   "platform detection should detect" >> {
     "OS X" in {
       givenPlatformSetTo(OS_X)
-      v5_6_21.asInDownloadPath mustEqual "MySQL-5.6/mysql-5.6.21-osx10.9"
+      v5_7_15.asInDownloadPath mustEqual "MySQL-5.7/mysql-5.7.15-osx10.11"
     }
 
     "Windows" in {
       givenPlatformSetTo(Windows)
-      v5_6_21.asInDownloadPath mustEqual "MySQL-5.6/mysql-5.6.21"
+      v5_7_15.asInDownloadPath mustEqual "MySQL-5.7/mysql-5.7.15"
     }
 
     "Linux" in {
       givenPlatformSetTo(Linux)
-      v5_5_40.asInDownloadPath mustEqual "MySQL-5.5/mysql-5.5.40-linux2.6"
+      v5_7_15.asInDownloadPath mustEqual "MySQL-5.7/mysql-5.7.15-linux-glibc2.5"
     }
   }
 
   "verify that" >> {
     "windows for 5.5.X is not supported" in {
       givenPlatformSetTo(Windows)
-      v5_5_40.asInDownloadPath must throwA[UnsupportedPlatformException]
+      v5_5_latest.asInDownloadPath must throwA[UnsupportedPlatformException]
     }
 
     "solaris is not supported" in {
       givenPlatformSetTo(Solaris)
-      v5_5_40.asInDownloadPath must throwA[UnsupportedPlatformException]
+      v5_5_latest.asInDownloadPath must throwA[UnsupportedPlatformException]
     }
 
     "freebsd is not supported" in {
       givenPlatformSetTo(FreeBSD)
-      v5_5_40.asInDownloadPath must throwA[UnsupportedPlatformException]
+      v5_5_latest.asInDownloadPath must throwA[UnsupportedPlatformException]
     }
   }
 


### PR DESCRIPTION
An updated version of #67 that does not include support for MySQL 5.7.11, hopefully fixing the CI build on Linux.