### PR TITLE
Fixed timeout not effective for process startup

### DIFF
--- a/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/EmbeddedMysqlTest.scala
@@ -1,5 +1,6 @@
 package com.wix.mysql
 
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.SECONDS
 
 import com.wix.mysql.EmbeddedMysql._
@@ -40,6 +41,11 @@ class EmbeddedMysqlTest extends IntegrationTest {
         haveCharsetOf(LATIN1) and
         beAvailableOn(1112, "zeUser", "zePassword", SystemDefaults.SCHEMA) and
         haveServerTimezoneMatching("US/Michigan")
+    }
+
+    "respect provided timeout" in {
+      start(anEmbeddedMysql(aMysqldConfig(v5_6_latest).withTimeout(10, TimeUnit.MILLISECONDS).build)) must
+        throwA[RuntimeException].like { case e => e.getMessage must contain("0 sec")}
     }
   }
 
@@ -177,11 +183,6 @@ class EmbeddedMysqlTest extends IntegrationTest {
       mysqld must haveSchemaCharsetOf(UTF8MB4, schemaConfig.getName)
 
       mysqld.addSchema(schemaConfig) must throwA[CommandFailedException]
-    }
-
-    "respect provided timeout" in {
-      start(anEmbeddedMysql(aMysqldConfig(v5_6_latest).withTimeout(1, SECONDS).build)) must
-        throwA[RuntimeException].like { case e => e.getMessage must contain("1 sec")}
     }
   }
 }

--- a/src/test/scala/com/wix/mysql/io/ResultMatchingListenerTest.scala
+++ b/src/test/scala/com/wix/mysql/io/ResultMatchingListenerTest.scala
@@ -1,0 +1,39 @@
+package com.wix.mysql.io
+
+import com.wix.mysql.io.NotifyingStreamProcessor.ResultMatchingListener
+import org.specs2.mutable.SpecWithJUnit
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ResultMatchingListenerTest extends SpecWithJUnit {
+
+  "ResultMatchingListenerTest" should {
+
+    "should return given output pattern matched expected expression" in {
+      val listener = new ResultMatchingListener("SUCCESS")
+      Future {
+        Thread.sleep(1000)
+        listener.onMessage("SUCCESS")
+      }
+
+      try {
+        new ResultMatchingListener("SUCCESS").waitForResult(4000)
+      } catch {
+        case e: Exception => {
+          println(e)
+        }
+      }
+
+      listener.isInitWithSuccess must beTrue
+    }
+
+    "throw an exception if command does not complete within provided timeout" in {
+      new ResultMatchingListener("SUCCESS").waitForResult(1000) must
+        throwA[RuntimeException].like { case e => e.getMessage must contain("Timeout of 1 sec exceeded")}
+    }
+
+
+  }
+
+}

--- a/src/test/scala/com/wix/mysql/io/ResultMatchingListenerTest.scala
+++ b/src/test/scala/com/wix/mysql/io/ResultMatchingListenerTest.scala
@@ -17,23 +17,15 @@ class ResultMatchingListenerTest extends SpecWithJUnit {
         listener.onMessage("SUCCESS")
       }
 
-      try {
-        new ResultMatchingListener("SUCCESS").waitForResult(4000)
-      } catch {
-        case e: Exception => {
-          println(e)
-        }
-      }
+      listener.waitForResult(4000)
 
       listener.isInitWithSuccess must beTrue
     }
 
     "throw an exception if command does not complete within provided timeout" in {
       new ResultMatchingListener("SUCCESS").waitForResult(1000) must
-        throwA[RuntimeException].like { case e => e.getMessage must contain("Timeout of 1 sec exceeded")}
+        throwA[RuntimeException].like { case e => e.getMessage must contain("Timeout of 1 sec exceeded") }
     }
-
-
   }
 
 }


### PR DESCRIPTION
Followup fix for #71. Windows builds uncovered, that timeout did not kick-in properly for process start-up - only for init.