### PR TITLE
Feature/issue 80 macosx sierra and https

### DIFF
--- a/src/main/java/com/wix/mysql/config/DownloadConfigBuilder.java
+++ b/src/main/java/com/wix/mysql/config/DownloadConfigBuilder.java
@@ -11,7 +11,7 @@ public class DownloadConfigBuilder extends de.flapdoodle.embed.process.config.st
 
     public DownloadConfigBuilder defaults() {
         fileNaming().setDefault(new UUIDTempNaming());
-        downloadPath().setDefault(new DownloadPath("http://dev.mysql.com/get/Downloads/"));
+        downloadPath().setDefault(new DownloadPath("https://dev.mysql.com/get/Downloads/"));
         progressListener().setDefault(new StandardConsoleProgressListener());
         artifactStorePath().setDefault(new UserHome(".embedmysql"));
         downloadPrefix().setDefault(new DownloadPrefix("embedmysql-download"));

--- a/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/src/main/java/com/wix/mysql/distribution/Version.java
@@ -1,13 +1,14 @@
 package com.wix.mysql.distribution;
 
-import static java.lang.String.format;
-
 import com.wix.mysql.exceptions.UnsupportedPlatformException;
 import com.wix.mysql.utils.Utils;
 import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.process.distribution.Platform;
+
 import java.util.Arrays;
 import java.util.List;
+
+import static java.lang.String.format;
 
 public enum Version implements IVersion {
 
@@ -28,10 +29,12 @@ public enum Version implements IVersion {
     v5_7_13("5.7", 13, MacOsVersion.v10_11),
     v5_7_14("5.7", 14, MacOsVersion.v10_11),
     v5_7_15("5.7", 15, MacOsVersion.v10_11),
-    v5_7_latest(v5_7_15);
+    v5_7_16("5.7", 16, MacOsVersion.v10_11),
+    v5_7_17("5.7", 17, MacOsVersion.v10_12),
+    v5_7_latest(v5_7_17);
 
     private enum MacOsVersion {
-        v10_6, v10_9, v10_10, v10_11;
+        v10_6, v10_9, v10_10, v10_11, v10_12;
 
         @Override
         public String toString() {

--- a/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/src/main/java/com/wix/mysql/distribution/Version.java
@@ -30,11 +30,10 @@ public enum Version implements IVersion {
     v5_7_14("5.7", 14, MacOsVersion.v10_11),
     v5_7_15("5.7", 15, MacOsVersion.v10_11),
     v5_7_16("5.7", 16, MacOsVersion.v10_11),
-    v5_7_17("5.7", 17, MacOsVersion.v10_12),
-    v5_7_latest(v5_7_17);
+    v5_7_latest(v5_7_16);
 
     private enum MacOsVersion {
-        v10_6, v10_9, v10_10, v10_11, v10_12;
+        v10_6, v10_9, v10_10, v10_11;
 
         @Override
         public String toString() {


### PR DESCRIPTION
To sum things up:

1) Changed download protocol from 'http' to 'https' because Oracle supports http only as a redirect, which does not work with this setup.
2) Added support for newer version of MySQL: 5.7.16. Did not introduce 5.7.17 as it has a different file name ('macos' instead of 'osx' for OS name indicator)