### PR TITLE
#98 MysqlClient: always connect to localhost.

### DIFF
--- a/src/main/java/com/wix/mysql/MysqlClient.java
+++ b/src/main/java/com/wix/mysql/MysqlClient.java
@@ -50,6 +50,8 @@ class MysqlClient {
             Process p = new ProcessBuilder(new String[]{
                     Paths.get(executable.getBaseDir().getAbsolutePath(), "bin", "mysql").toString(),
                     "--protocol=tcp",
+                    "--host=localhost",
+                    "--password=",
                     format("--user=%s", SystemDefaults.USERNAME),
                     format("--port=%s", config.getPort()),
                     schemaName}).start();

--- a/src/test/scala/com/wix/mysql/MysqlTest.scala
+++ b/src/test/scala/com/wix/mysql/MysqlTest.scala
@@ -13,7 +13,7 @@ class MysqlTest extends IntegrationTest {
 
     mysql.executeCommands("sele qwe from zz;") must throwA[CommandFailedException].like {
       case e: CommandFailedException => e.getMessage must contain(
-        "output 'ERROR 1064 (42000) at line 1: You have an error in your SQL syntax;")
+        "ERROR 1064 (42000) at line 1: You have an error in your SQL syntax;")
     }
   }
 }


### PR DESCRIPTION
Solves #98.

Note: using a password on the command line results in a warning if MySQL 5.6 or later is used:

```
Warning: Using a password on the command line interface can be insecure.
```

In my opinion, this warning can be ignored as no password is set.