### PR TITLE
Support free port on MysqldConfig

### DIFF
--- a/src/main/java/com/wix/mysql/config/MysqldConfig.java
+++ b/src/main/java/com/wix/mysql/config/MysqldConfig.java
@@ -5,6 +5,8 @@ import de.flapdoodle.embed.process.config.ExecutableProcessConfig;
 import de.flapdoodle.embed.process.config.ISupportConfig;
 import de.flapdoodle.embed.process.distribution.IVersion;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
@@ -115,6 +117,13 @@ public class MysqldConfig extends ExecutableProcessConfig {
         public Builder withPort(int port) {
             this.port = port;
             return this;
+        }
+
+        public Builder withFreePort() throws IOException {
+            try (ServerSocket socket = new ServerSocket(0)) {
+                socket.setReuseAddress(true);
+                return withPort(socket.getLocalPort());
+            }
         }
 
         public Builder withTimeout(long length, TimeUnit unit) {

--- a/src/test/scala/com/wix/mysql/config/MysqldConfigTest.scala
+++ b/src/test/scala/com/wix/mysql/config/MysqldConfigTest.scala
@@ -54,10 +54,19 @@ class MysqldConfigTest extends SpecWithJUnit {
         Seq("--some-int=123", "--some-string=one", "--some-boolean=false")
     }
 
+    "accept free port" in {
+      val mysqldConfig = aMysqldConfig(v5_6_latest)
+        .withFreePort()
+        .build()
+
+      mysqldConfig.getPort mustNotEqual 3310
+    }
+
     "fail if building with user 'root'" in {
       aMysqldConfig(v5_6_latest)
         .withUser("root", "doesnotmatter")
         .build() must throwA[IllegalArgumentException](message = "Usage of username 'root' is forbidden")
     }
+
   }
 }


### PR DESCRIPTION
I use the wix-embedded-mysql by unit or integration testing using JUnit.
I want to support builder method for allocating a free port on `MysqldConfig`.

What do you think ?