### PR TITLE
Added support for versions 5.7.18 and 5.7.19 and set v5_7_latest to 5.7.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ Build on top of [de.flapdoodle.embed.process](https://github.com/flapdoodle-oss/
  - windows 2012;
 
 # Known issues
- - mysql, starting version 5.5.10 requires `libaio1.so` to be preinstalled on linux, but that is not the case for some linux distributions. Proper error is emitted if it's missing and you have to install it manually (ex. ubuntu):
+ - starting version 5.7.18, Microsoft Visual C++ 2013 Redistributable Package needs to be pre-installed on windows.
+ - starting version 5.5.10 `libaio1.so` needs to be pre-installed on linux, but that is not the case for some linux distributions. Proper error is emitted if it's missing and you have to install it manually (ex. ubuntu):
 ```bash
 sudo apt-get install libaio1
 ```

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/FileSet.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/FileSet.java
@@ -10,6 +10,7 @@ public class FileSet {
     private static List<FileSetEmitter> emitters = Collections.newArrayList(
             new Win56FileSetEmitter(),
             new Win57FileSetEmitter(),
+            new Win57_18_UpFileSetEmitter(),
             new Nix55FileSetEmitter(),
             new Nix56FileSetEmitter(),
             new Nix57FileSetEmitter(),

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/FileSet.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/FileSet.java
@@ -12,7 +12,8 @@ public class FileSet {
             new Win57FileSetEmitter(),
             new Nix55FileSetEmitter(),
             new Nix56FileSetEmitter(),
-            new Nix57FileSetEmitter());
+            new Nix57FileSetEmitter(),
+            new Nix57_18_AndUpFileSetEmitter());
 
     public static de.flapdoodle.embed.process.config.store.FileSet emit(
             final Platform platform,

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
@@ -152,3 +152,4 @@ public enum Version implements IVersion {
         return minorVersion;
     }
 }
+

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
@@ -111,7 +111,9 @@ public enum Version implements IVersion {
     }
 
     private String gcLibVersion() {
-        if (majorVersion.equals("5.6") || majorVersion.equals("5.7"))
+        if(majorVersion.equals("5.7") && minorVersion > 18)
+            return "linux-glibc2.12";
+        if (majorVersion.equals("5.6") || (majorVersion.equals("5.7") && minorVersion <= 18))
             return "linux-glibc2.5";
         if (majorVersion.equals("5.5"))
             return "linux2.6";

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/Version.java
@@ -34,7 +34,9 @@ public enum Version implements IVersion {
     v5_7_15("5.7", 15, MacOsVersion.v10_11),
     v5_7_16("5.7", 16, MacOsVersion.v10_11),
     v5_7_17("5.7", 17, MacOsVersion.v10_12),
-    v5_7_latest(v5_7_17);
+    v5_7_18("5.7", 18, MacOsVersion.v10_12),
+    v5_7_19("5.7", 19, MacOsVersion.v10_12),
+    v5_7_latest(v5_7_19);
 
     private enum MacOsVersion {
         v10_6("osx"), v10_9("osx"), v10_10("osx"), v10_11("osx"),
@@ -142,5 +144,9 @@ public enum Version implements IVersion {
 
     public String getMajorVersion() {
         return majorVersion;
+    }
+
+    public int getMinorVersion() {
+        return minorVersion;
     }
 }

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/fileset/Nix57_18_AndUpFileSetEmitter.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/fileset/Nix57_18_AndUpFileSetEmitter.java
@@ -8,19 +8,18 @@ import java.util.Objects;
 
 import static de.flapdoodle.embed.process.config.store.FileType.Library;
 
-public class Nix57FileSetEmitter extends Nix implements FileSetEmitter {
+public class Nix57_18_AndUpFileSetEmitter extends Nix implements FileSetEmitter {
     @Override
     public boolean matches(Platform platform, Version version) {
         return platform.isUnixLike()
                 && Objects.equals(version.getMajorVersion(), "5.7")
-                && version.getMinorVersion() <= 17;
+                && version.getMinorVersion() > 17;
     }
 
     @Override
     public FileSet emit() {
         return common()
                 .addEntry(Library, "share/mysql_security_commands.sql")
-                .addEntry(Library, "support-files/my-default.cnf")
                 .build();
     }
 }

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/fileset/Win57_18_UpFileSetEmitter.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/fileset/Win57_18_UpFileSetEmitter.java
@@ -9,20 +9,18 @@ import java.util.Objects;
 import static de.flapdoodle.embed.process.config.store.FileType.Executable;
 import static de.flapdoodle.embed.process.config.store.FileType.Library;
 
-public class Win57FileSetEmitter implements FileSetEmitter {
+public class Win57_18_UpFileSetEmitter implements FileSetEmitter {
     @Override
     public boolean matches(Platform platform, Version version) {
-        return !platform.isUnixLike() &&
-                Objects.equals(version.getMajorVersion(), "5.7") &&
-                version.getMinorVersion() <= 17;
+        return !platform.isUnixLike()
+                && Objects.equals(version.getMajorVersion(), "5.7")
+                && version.getMinorVersion() > 17;
     }
 
     @Override
     public FileSet emit() {
         return FileSet.builder()
                 .addEntry(Executable, "bin/mysqld.exe")
-                .addEntry(Library, "bin/msvcp120.dll")
-                .addEntry(Library, "bin/msvcr120.dll")
                 .addEntry(Library, "bin/mysql.exe")
                 .addEntry(Library, "bin/mysqladmin.exe")
                 .addEntry(Library, "share/english/errmsg.sys")

--- a/wix-embedded-mysql/src/test/scala/com/wix/mysql/distribution/MacOsSierraTest.scala
+++ b/wix-embedded-mysql/src/test/scala/com/wix/mysql/distribution/MacOsSierraTest.scala
@@ -9,9 +9,8 @@ import org.specs2.specification.AroundEach
 import org.specs2.specification.core.Fragment
 
 class MacOsSierraTest extends SpecWithJUnit with Around with AroundEach {
-  sequential
 
-  val unsupportedVersions: Array[Version] = Version.values filter (!_.supportsCurrentPlatform)
+  val unsupportedVersions = Version.values filter (!_.supportsCurrentPlatform)
 
   Fragment.foreach(unsupportedVersions) { version =>
 
@@ -27,7 +26,7 @@ class MacOsSierraTest extends SpecWithJUnit with Around with AroundEach {
     val currentOsName = getProperty("os.name")
     val currentOsVersion = getProperty("os.version")
 
-    setProperty("os.name", "Mac OS X")
+    setProperty("os.name", "Mac OS X");
     setProperty("os.version", "10.12")
 
     try AsResult(r)

--- a/wix-embedded-mysql/src/test/scala/com/wix/mysql/distribution/MacOsSierraTest.scala
+++ b/wix-embedded-mysql/src/test/scala/com/wix/mysql/distribution/MacOsSierraTest.scala
@@ -9,8 +9,9 @@ import org.specs2.specification.AroundEach
 import org.specs2.specification.core.Fragment
 
 class MacOsSierraTest extends SpecWithJUnit with Around with AroundEach {
+  sequential
 
-  val unsupportedVersions = Version.values filter (!_.supportsCurrentPlatform)
+  val unsupportedVersions: Array[Version] = Version.values filter (!_.supportsCurrentPlatform)
 
   Fragment.foreach(unsupportedVersions) { version =>
 
@@ -26,7 +27,7 @@ class MacOsSierraTest extends SpecWithJUnit with Around with AroundEach {
     val currentOsName = getProperty("os.name")
     val currentOsVersion = getProperty("os.version")
 
-    setProperty("os.name", "Mac OS X");
+    setProperty("os.name", "Mac OS X")
     setProperty("os.version", "10.12")
 
     try AsResult(r)

--- a/wix-embedded-mysql/src/test/scala/com/wix/mysql/distribution/VersionTest.scala
+++ b/wix-embedded-mysql/src/test/scala/com/wix/mysql/distribution/VersionTest.scala
@@ -35,6 +35,8 @@ class VersionTest extends SpecWithJUnit with AroundEach {
     "Linux" in {
       givenPlatformSetTo(Linux)
       v5_7_15.asInDownloadPath mustEqual "/MySQL-5.7/mysql-5.7.15-linux-glibc2.5"
+      v5_7_18.asInDownloadPath mustEqual "/MySQL-5.7/mysql-5.7.18-linux-glibc2.5"
+      v5_7_19.asInDownloadPath mustEqual  "/MySQL-5.7/mysql-5.7.19-linux-glibc2.12"
     }
 
   }


### PR DESCRIPTION
Had to create a separate Nix Emitter for 5.7.18 and up, which doesn't require `support-files/my-default.cnf`.
This file is no longer in these versions.