### PR TITLE
add link to MariaDB4j in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,5 +193,8 @@ Build on top of [de.flapdoodle.embed.process](https://github.com/flapdoodle-oss/
 sudo apt-get install libaio1
 ```
 
-#License
+# License
 Use of this source code is governed by a [BSD License](LICENSE.md), which basically means you can use and modify it freely.
+
+# Similar project
+[MariaDB4j](https://github.com/vorburger/MariaDB4j) is an unrelated similar project.


### PR DESCRIPTION
Looks like you guys and I have built two very similar projects - are you aware of my [MariaDB4j](https://github.com/vorburger/MariaDB4j)?

I would be open to and think it would be a service to our respective users if we cross linked to each other, e.g. at the end of our respective README.md - would you have any interest and be open to that?