### PR TITLE
Expose option to execute arbitrary sql scripts in tests

### DIFF
--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/EmbeddedMysql.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/EmbeddedMysql.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -71,6 +72,14 @@ public class EmbeddedMysql {
     public void dropSchema(final SchemaConfig schema) {
         Charset effectiveCharset = or(schema.getCharset(), config.getCharset());
         getClient(SystemDefaults.SCHEMA, effectiveCharset).executeCommands(format("DROP DATABASE %s", schema.getName()));
+    }
+    
+    public void executeScripts(final String schemaName, final SqlScriptSource... scripts) {
+        getClient(schemaName, config.getCharset()).executeScripts(Arrays.asList(scripts));
+    }
+    
+    public void executeScripts(final String schemaName, final List<SqlScriptSource> scripts) {
+        getClient(schemaName, config.getCharset()).executeScripts(scripts);
     }
 
     public EmbeddedMysql addSchema(final SchemaConfig schema) {

--- a/wix-embedded-mysql/src/test/resources/data/arbitrary_script.sql
+++ b/wix-embedded-mysql/src/test/resources/data/arbitrary_script.sql
@@ -1,0 +1,1 @@
+INSERT INTO t1 values(20)


### PR DESCRIPTION
It would be nice to be able to execute sql scripts from files using the EmbeddedMysql API. I know that you can create your own datasource for executing arbitrary queries, but this approach as far as I understand would handle longer scripts better. WDYT?