### PR TITLE
take daylight savings into account

### DIFF
--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/utils/Utils.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/utils/Utils.java
@@ -3,6 +3,7 @@ package com.wix.mysql.utils;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.CharBuffer;
+import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -22,7 +23,7 @@ public class Utils {
     }
 
     public static String asHHmmOffset(TimeZone timeZone) {
-        long offsetInMillis = timeZone.getRawOffset();
+        long offsetInMillis = timeZone.getOffset(Calendar.getInstance().getTimeInMillis());
         return format("%s%02d:%02d",
                 offsetInMillis >= 0 ? "+" : "-",
                 Math.abs(MILLISECONDS.toHours(offsetInMillis)),

--- a/wix-embedded-mysql/src/test/scala/com/wix/mysql/UtilsTest.scala
+++ b/wix-embedded-mysql/src/test/scala/com/wix/mysql/UtilsTest.scala
@@ -1,0 +1,21 @@
+package com.wix.mysql
+
+import java.util.{Calendar, Date, SimpleTimeZone}
+
+import com.wix.mysql.utils.Utils
+import org.specs2.mutable.SpecWithJUnit
+
+class UtilsTest extends SpecWithJUnit {
+  "Utils" should {
+    "take daylight savings into account" in {
+      val cal = Calendar.getInstance()
+      val millisInHour = 60 * 60 * 1000
+      // this fake tz should always be in daylight time:
+      val tz = new SimpleTimeZone(millisInHour * -5, "EDT", Calendar.JANUARY, 1, 0, 0, Calendar.DECEMBER, 31, 0, millisInHour * 24 - 1, millisInHour)
+      val offset = Utils.asHHmmOffset(tz)
+      tz.observesDaylightTime() mustEqual true
+      tz.inDaylightTime(new Date()) mustEqual true
+      offset mustEqual "-04:00"
+    }
+  }
+}


### PR DESCRIPTION
hey, first of all, thanks for this project, it's been extremely useful for us.
I noticed that when using the "withTimezone" configuration setting it to "CST6CDT" that the `mysqld` process was getting the parameter `--default-time-zone=-06:00`. Since we are in daylight time right now, it should actually be `-05:00`

I think the method `asHHmmOffset` should take DST into account when calculating an offset. But perhaps I misunderstood and there is an alternative way you want to manage DST... I'm opening this PR with the test just to demonstrate what I think is the problem.

there's an open issue about this which I suspect is the same probem https://github.com/wix/wix-embedded-mysql/issues/139

thanks again.
M