### PR TITLE
Proxy support for DownloadAndExtract tool

### DIFF
--- a/wix-embedded-mysql-download-and-extract/src/main/java/com/wix/mysql/MysqlDownloadAndExtract.java
+++ b/wix-embedded-mysql-download-and-extract/src/main/java/com/wix/mysql/MysqlDownloadAndExtract.java
@@ -5,13 +5,22 @@ import com.wix.mysql.config.MysqldConfig;
 import com.wix.mysql.config.RuntimeConfigBuilder;
 import com.wix.mysql.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.store.HttpProxyFactory;
+import de.flapdoodle.embed.process.config.store.IProxyFactory;
+import de.flapdoodle.embed.process.config.store.NoProxyFactory;
 
 import static com.wix.mysql.config.DownloadConfig.aDownloadConfig;
 
 public class MysqlDownloadAndExtract {
+        private static final String PROXY_HOST = System.getProperty("http.proxyHost", null);
+        private static final int PROXY_PORT = Integer.valueOf(System.getProperty("http.proxyPort", "0"));
 
     public static void main(String[] args) {
-        DownloadConfig downloadConfig = aDownloadConfig().withCacheDir(args[0]).build();
+        IProxyFactory proxy = new NoProxyFactory();
+        if (PROXY_HOST != null){
+            proxy = new HttpProxyFactory(PROXY_HOST, PROXY_PORT);
+        }
+        DownloadConfig downloadConfig = aDownloadConfig().withCacheDir(args[0]).withProxy(proxy).build();
         MysqldConfig mysqldConfig = MysqldConfig.aMysqldConfig(Version.valueOf(version(args))).build();
         IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(mysqldConfig, downloadConfig).build();
         MysqldStarter mysqldStarter = new MysqldStarter(runtimeConfig);


### PR DESCRIPTION
Enabling proxy for the wix-embedded-mysql-download-and-extract utility with sytem properties:
- http.proxyHost
- http.proxyPort